### PR TITLE
docs: split CLAUDE.md into nested files for progressive disclosure

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,6 @@
 # CLAUDE.md
 
-This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+Guidance for Claude Code (claude.ai/code) working in this repository.
 
 ## Commands
 
@@ -13,43 +13,32 @@ pnpm format       # Biome format only
 pnpm typegen      # regenerate Next.js typed routes
 ```
 
-No test suite — this is a portfolio site.
+No test suite — this is a portfolio site. Use `pnpm`, never `npm`.
 
-## Architecture
+## Stack
 
-Next.js 16 App Router portfolio site. React 19 with React Compiler enabled. TypeScript strict mode. `@/` maps to the repo root.
+Next.js 16 App Router. React 19 with React Compiler enabled. TypeScript strict mode. `@/` maps to the repo root.
 
-**`app/`** — pages only. No business logic here.
-- `app/page.tsx` — single-page home: hero, applications section, libraries section, contact section
-- `app/projects/[slug]/page.tsx` — individual case study pages for each project
-- `app/layout.tsx` — root layout: Google Fonts (Figtree + JetBrains Mono as CSS vars), `<Providers>`, `<BackgroundFx>`, `<LayoutHeader>`
+## Layout
 
-**`components/`** — all components
-- `components/ui/` — shadcn/ui primitives. These have their own `biome.json` that relaxes rules for generated code. Don't edit these manually; use `pnpm dlx shadcn add <component>`.
-- `components/project-summary.tsx` — compound components for project cards on the home page
-- `components/project-section.tsx` — heading/divider components for case study pages
-- `components/code-block.tsx` — **async Server Component** using Shiki for SSR syntax highlighting (catppuccin-latte/mocha themes)
-- `components/framework-badge.tsx` — `<FrameworkBadge version="...">`. Adding a new badge requires extending the `FrameworkVersion` union and `displayLabels` map in that file.
+Subsystem detail lives in nested `CLAUDE.md` files that load on demand when you open that directory:
 
-**`lib/`** — shared utilities
-- `lib/utils.ts` — `cn()` helper (clsx + tailwind-merge)
-- `lib/query-client.ts` — TanStack Query client singleton
-- `lib/opengraph.tsx` — shared OG image utilities
+- `app/` — pages only, no business logic. See `app/CLAUDE.md`.
+  - `app/projects/` — case study pages. See `app/projects/CLAUDE.md`.
+- `components/` — all components. See `components/CLAUDE.md`.
+  - `components/ui/` — generated shadcn primitives. See `components/ui/CLAUDE.md`.
+  - `components/mdx/` — MDX rendering. See `components/mdx/CLAUDE.md`.
+- `lib/` — shared utilities, incl. the articles pipeline. See `lib/CLAUDE.md`.
+- `content/articles/` — article `.mdx` source. See `content/articles/CLAUDE.md`.
 
-## Key patterns
-
-**Images** — every project screenshot has four variants: `{name}-dark.png`, `{name}-light.png`, `{name}-dark-mobile.png`, `{name}-light-mobile.png`. Visibility is controlled with Tailwind classes: `hidden dark:block sm:dark:hidden` etc. Follow this same pattern when adding new project images.
-
-**Structured data** — each project route has a `structured-data.json` colocated alongside its `page.tsx`, injected via `<JsonLd data={...} />`.
-
-**MDX components** — custom components usable in article `.mdx` are registered in the `components` map in `components/mdx/mdx-content.tsx`. Client components (`"use client"`) work there as client islands within the RSC-rendered MDX.
-
-**Typed routes** — `next.config.ts` enables `typedRoutes: true`. Always use typed `href` props (e.g. `link={{ href: "/projects/parasol" }}`). Run `pnpm typegen` if route types are stale.
+## Conventions (apply everywhere)
 
 **Theme** — `next-themes` with `attribute="class"`. Both light and dark modes must be considered for any new visual element.
 
-## Tooling notes
+**Typed routes** — `next.config.ts` enables `typedRoutes: true`. Always use typed `href` props (e.g. `link={{ href: "/projects/parasol" }}`). Run `pnpm typegen` if route types are stale.
 
-**Biome 2.x** is the linter and formatter (no ESLint, no Prettier). Double quotes for JS/TS strings. Imports are auto-organized on save via Biome assist. `tailwindDirectives: true` is set in `biome.json` — do not disable CSS linting to work around Tailwind `@` directives.
+**Biome 2.x** is the primary linter and formatter (no Prettier). `pnpm lint` runs `biome check`. An `eslint.config.mjs` (`eslint-config-next`) also exists for Next.js core-web-vitals rules but is not part of `pnpm lint`. Double quotes for JS/TS strings. Imports are auto-organized on save via Biome assist. `tailwindDirectives: true` is set in `biome.json` — do not disable CSS linting to work around Tailwind `@` directives.
 
-**shadcn/ui** — use the `shadcn` CLI to add components. Don't hand-edit files in `components/ui/`. shadcn primitives in this project are built on **Base UI** (`@base-ui/react`), not Radix — the component API (e.g. `Popover.Positioner`/`Popover.Popup`) and props differ from Radix equivalents.
+**Pre-commit** — `lefthook.yml` runs `biome check --write` on staged JS/TS/JSON/CSS files and re-stages fixes.
+
+**shadcn primitives are built on Base UI (`@base-ui/react`), not Radix** — the API differs (e.g. `Popover.Positioner` / `Popover.Popup`). Details in `components/ui/CLAUDE.md`.

--- a/app/CLAUDE.md
+++ b/app/CLAUDE.md
@@ -1,0 +1,12 @@
+# app/ — App Router pages
+
+Pages only. No business logic here — extract to `lib/` or `components/`.
+
+- `page.tsx` — single-page home: hero, applications section, libraries section, contact section
+- `layout.tsx` — root layout: Google Fonts (Figtree + JetBrains Mono as CSS vars), `<Providers>`, `<BackgroundFx>`, `<LayoutHeader>`
+- `articles/`, `articles/[slug]/page.tsx` — article index + individual MDX articles
+- `projects/[slug]/page.tsx` — case study pages (see `projects/CLAUDE.md`)
+
+**SEO / metadata** — `sitemap.ts`, `robots.ts`, `manifest.ts`, and `rss.xml/route.ts` are generated routes. Keep them in sync when adding routes or articles.
+
+**OG images** — every route has a colocated `opengraph-image.tsx`. Dynamic routes (`[slug]`) export `generateStaticParams` and build the image with `next/og` `ImageResponse`, using `loadFonts` / `OG_COLORS` / `OgMark` from `@/lib/opengraph`.

--- a/app/projects/CLAUDE.md
+++ b/app/projects/CLAUDE.md
@@ -1,0 +1,7 @@
+# app/projects/ — case study pages
+
+**Images** — every project screenshot has four variants: `{name}-dark.png`, `{name}-light.png`, `{name}-dark-mobile.png`, `{name}-light-mobile.png`. Visibility is controlled with Tailwind classes: `hidden dark:block sm:dark:hidden` etc. Follow this pattern when adding new project images.
+
+**Structured data** — each project route has a `structured-data.json` colocated alongside its `page.tsx`, injected via `<JsonLd data={...} />`.
+
+Section headings on these pages use `<ProjectSectionHeading>` / `<ProjectSectionDivider>` from `@/components/project-section`.

--- a/components/CLAUDE.md
+++ b/components/CLAUDE.md
@@ -1,0 +1,8 @@
+# components/ — all components
+
+- `project-summary.tsx` — compound components for project cards on the home page
+- `project-section.tsx` — `<ProjectSectionHeading>` / `<ProjectSectionDivider>` for case study pages
+- `code-block.tsx` — **async Server Component** using Shiki for SSR syntax highlighting (catppuccin-latte/mocha themes)
+- `framework-badge.tsx` — `<FrameworkBadge version="...">`. Adding a new badge requires extending the `FrameworkVersion` union and `displayLabels` map in that file.
+
+Subdirectories carry their own `CLAUDE.md`: `ui/` (generated primitives), `mdx/` (MDX rendering).

--- a/components/mdx/CLAUDE.md
+++ b/components/mdx/CLAUDE.md
@@ -1,0 +1,5 @@
+# components/mdx/ — MDX rendering
+
+Articles are rendered with `next-mdx-remote/rsc` (`MdxContent` in `mdx-content.tsx`), with `rehype-slug` applied so headings get `id`s for the TOC.
+
+**Custom components** usable in article `.mdx` are registered in the `components` map in `mdx-content.tsx`. Client components (`"use client"`) work there as client islands within the RSC-rendered MDX. Current map: `pre`, `code`, `a` (internal links via typed `next/link`; external links get `target="_blank"` + `rel="noopener noreferrer"`), `BrandMark`, `ButtonLink`, `CodeBlock`, `Define`, `FrameworkBadge`.

--- a/components/ui/CLAUDE.md
+++ b/components/ui/CLAUDE.md
@@ -1,0 +1,5 @@
+# components/ui/ — shadcn primitives
+
+**Generated code — do not hand-edit.** Add or update primitives with the `shadcn` CLI (`pnpm dlx shadcn add <component>`). This directory has its own `biome.json` that relaxes rules for generated code.
+
+These primitives are built on **Base UI (`@base-ui/react`), not Radix.** The component API and props differ from Radix equivalents — e.g. `Popover.Positioner` / `Popover.Popup`. Consult Base UI docs, not Radix, when composing them.

--- a/content/articles/CLAUDE.md
+++ b/content/articles/CLAUDE.md
@@ -1,0 +1,13 @@
+# content/articles/ — article source
+
+One `.mdx` file per article; the filename (minus `.mdx`) is the slug.
+
+**Frontmatter** is validated by a Zod schema in `@/lib/articles`:
+- required: `title`, `description`, `date`
+- optional: `updated`, `tags` (string[]), `draft` (boolean)
+
+**Drafts** (`draft: true`) render only when `NODE_ENV !== "production"` — hidden in the production build.
+
+**TOC** is derived from `##`/`###` headings via regex, so heading text drives the anchor slug. Reading time is computed automatically.
+
+Custom MDX components (`<Define>`, `<CodeBlock>`, `<FrameworkBadge>`, etc.) are registered in `components/mdx/mdx-content.tsx`. For voice and authoring workflow, use the `article-writing` skill.


### PR DESCRIPTION
## What

Restructure `CLAUDE.md` into a lean root plus seven nested `CLAUDE.md` files that Claude Code loads on demand per subtree.

**Currency fixes (root):**
- Document the articles/MDX subsystem (`content/articles/`, `lib/articles.ts`, RSS, sitemap/robots/manifest).
- Correct the stale "no ESLint" note — `eslint.config.mjs` (`eslint-config-next`) exists but isn't part of `pnpm lint`.
- Add the `lefthook` pre-commit note.

**Progressive-disclosure split:**

| File | Loads when you open | Holds |
|------|---------------------|-------|
| `CLAUDE.md` (root) | always | commands, stack, layout map, cross-cutting conventions |
| `app/CLAUDE.md` | `app/` | pages-only rule, SEO routes, OG image pattern |
| `app/projects/CLAUDE.md` | a case study | image four-variant pattern, structured-data |
| `components/CLAUDE.md` | any component | project-summary, code-block, framework-badge |
| `components/ui/CLAUDE.md` | a primitive | "generated, don't hand-edit", Base UI footgun |
| `components/mdx/CLAUDE.md` | MDX code | RSC rendering, components map, rehype-slug |
| `lib/CLAUDE.md` | `lib/` | utilities + the articles pipeline |
| `content/articles/CLAUDE.md` | an `.mdx` | frontmatter schema, drafts, TOC, glossary |

## Why

The root `CLAUDE.md` is loaded into context on every session. Pushing subsystem detail into nested files keeps the always-on footprint small — per-area context is paid for only when that area is touched. The Base UI footgun warning now fires exactly when editing a `components/ui/` primitive, and the articles-pipeline note sits in `lib/CLAUDE.md` so it loads when editing `lib/articles.ts` (not only when writing `.mdx`).

## Notes for reviewer

- Docs only — no functional/build impact.
- Trade-off: the footprint win lands on focused, single-subtree edits. A task spanning `app/` + `components/` + `lib/` pulls in several nested files anyway (same total, just deferred).
