### PR TITLE
feat(articles): add SourceCallout to guide readers to project sources

### DIFF
--- a/components/mdx/CLAUDE.md
+++ b/components/mdx/CLAUDE.md
@@ -2,4 +2,4 @@
 
 Articles are rendered with `next-mdx-remote/rsc` (`MdxContent` in `mdx-content.tsx`), with `rehype-slug` applied so headings get `id`s for the TOC.
 
-**Custom components** usable in article `.mdx` are registered in the `components` map in `mdx-content.tsx`. Client components (`"use client"`) work there as client islands within the RSC-rendered MDX. Current map: `pre`, `code`, `a` (internal links via typed `next/link`; external links get `target="_blank"` + `rel="noopener noreferrer"`), `BrandMark`, `ButtonLink`, `CodeBlock`, `Define`, `FrameworkBadge`.
+**Custom components** usable in article `.mdx` are registered in the `components` map in `mdx-content.tsx`. Client components (`"use client"`) work there as client islands within the RSC-rendered MDX. Current map: `pre`, `code`, `a` (internal links via typed `next/link`; external links get `target="_blank"` + `rel="noopener noreferrer"`), `BrandMark`, `ButtonLink`, `CodeBlock`, `Define`, `FrameworkBadge`, `SourceCallout` (block-level callout guiding readers to a project case study (`internal`) or external source (`external`)).

--- a/components/mdx/mdx-content.tsx
+++ b/components/mdx/mdx-content.tsx
@@ -9,6 +9,7 @@ import { Code } from "@/components/code";
 import { CodeBlock } from "@/components/code-block";
 import { Define } from "@/components/define";
 import { FrameworkBadge } from "@/components/framework-badge";
+import { SourceCallout } from "@/components/source-callout";
 import { Pre } from "./pre";
 
 function MdxLink({ href, children }: ComponentProps<"a">) {
@@ -36,6 +37,7 @@ const components = {
   CodeBlock,
   Define,
   FrameworkBadge,
+  SourceCallout,
 };
 
 export function MdxContent({ source }: { source: string }) {

--- a/components/source-callout.tsx
+++ b/components/source-callout.tsx
@@ -1,0 +1,57 @@
+import type { Route } from "next";
+import type { ReactNode } from "react";
+import { BrandMark } from "@/components/brand-mark";
+import { ButtonLink } from "@/components/button-link";
+
+type SourceCalloutBase = {
+  /** Override the mono `@`-kicker. Defaults to `@project` / `@source`. */
+  label?: string;
+  /** Name of the project or source, rendered as the callout title. */
+  title: string;
+  /** One-line description of what the reader finds by following the link. */
+  children: ReactNode;
+  /** Override the CTA text. */
+  cta?: string;
+};
+
+type SourceCalloutProps =
+  | (SourceCalloutBase & { internal: true; external?: false; href: Route })
+  | (SourceCalloutBase & { external: true; internal?: false; href: string });
+
+export function SourceCallout(props: SourceCalloutProps) {
+  const { title, children } = props;
+  const label = props.label ?? (props.internal ? "@project" : "@source");
+  const cta =
+    props.cta ?? (props.internal ? "Read the case study →" : "View source →");
+
+  return (
+    <aside className="not-prose my-8 rounded-lg border border-border bg-muted p-6">
+      <p className="flex items-center gap-2 font-mono text-sm text-secondary">
+        <BrandMark className="text-primary" />
+        {label}
+      </p>
+      <p className="mt-3 text-lg font-medium text-foreground">{title}</p>
+      <div className="mt-1 text-muted-foreground leading-relaxed">
+        {children}
+      </div>
+      <div className="mt-4">
+        {props.internal ? (
+          <ButtonLink internal link={{ href: props.href }}>
+            {cta}
+          </ButtonLink>
+        ) : (
+          <ButtonLink
+            external
+            link={{
+              href: props.href,
+              target: "_blank",
+              rel: "noopener noreferrer",
+            }}
+          >
+            {cta}
+          </ButtonLink>
+        )}
+      </div>
+    </aside>
+  );
+}

--- a/content/articles/option-type-in-dotnet.mdx
+++ b/content/articles/option-type-in-dotnet.mdx
@@ -116,3 +116,7 @@ Not everywhere. Nullable reference types (`T?`) are fine for small, internal det
 `User?` says it optionally. `Option<User>` says it unambiguously.
 
 The overhead is real. You write `.Match()` where you might have written an `if`. But that is the entire point. The `if` is optional; the compiler shrugs if you skip it. The `.Match()` is not. Rust proved you can make the safe path the only path — porting that discipline to .NET is just a matter of deciding the politeness was never enough.
+
+<SourceCallout internal href="/projects/waystone-monads" title="Waystone.Monads">
+  The full case study: design rationale, the Option and Result API surface, and the .NET compatibility matrix.
+</SourceCallout>

--- a/content/articles/skills-that-teach.mdx
+++ b/content/articles/skills-that-teach.mdx
@@ -95,3 +95,7 @@ And the principle-first style I have been selling has a real cost. Teaching skil
 So the honest rule is not "prefer freedom." It is the teaching test, applied per instruction: for each line, ask what the future agent needs to make this decision well without you in the room. Sometimes the answer is a reason; sometimes an exact command. The author's only real job is telling those two cases apart — and resisting the runbook that *feels* safe because it looks thorough.
 
 My skill for writing skills is still changing. That is the point. The version that stops changing is the one that has quietly become a runbook again.
+
+<SourceCallout external href="https://github.com/draekien/skills" title="draekien/skills">
+  The skill this article is about, still changing in the open: the SKILL.md, the anti-patterns, and the commit history of me learning the same lesson several times.
+</SourceCallout>


### PR DESCRIPTION
## What

Adds `SourceCallout`, a block-level MDX callout that hands article readers off to the real thing a piece references: an internal case study or an external source (repo/docs).

- **`components/source-callout.tsx`** (new) — discriminated-union props (`internal` → typed `Route` / `external` → `string`), mirroring `ButtonLink`. Reuses `BrandMark` + `ButtonLink`. On-brand: amber `\\` mark, Circuit Purple `@`-kicker, full border, `bg-muted`, flat (no shadow), `not-prose`. Server component.
- **`components/mdx/mdx-content.tsx`** — registered in the MDX `components` map.
- **`content/articles/option-type-in-dotnet.mdx`** — internal callout → `/projects/waystone-monads`.
- **`content/articles/skills-that-teach.mdx`** — external callout → `github.com/draekien/skills` (new tab, `rel="noopener noreferrer"`).
- **`components/mdx/CLAUDE.md`** — doc updated.

## Why

Articles that reference a codebase or a project the author worked on had no structured pointer to it. The Waystone.Monads article, for instance, is entirely about a library but never linked to its own case study. This makes that hand-off a deliberate, reusable component instead of an easy-to-miss inline link.

## Reviewer notes

- Defaults: `@project` / "Read the case study →" (internal), `@source` / "View source →" (external); both overridable via `label` / `cta`.
- `pnpm lint` and `pnpm build` pass; both articles prerender.
- Verified in the preview in light and dark: kicker, title, description, and CTA all render legibly; internal CTA resolves to the typed route, external opens in a new tab.