### PR TITLE
Flatten colophon to a hairline rule and clarify its copy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,6 +47,7 @@ next-env.d.ts
 .claude/settings.local.json
 .copilot
 .playwright-mcp/
+.impeccable/critique/
 
 # Worktrees
 .worktrees

--- a/app/articles/[slug]/page.tsx
+++ b/app/articles/[slug]/page.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from "next";
 import { ArticleToc } from "@/components/article-toc";
 import { BrandMark } from "@/components/brand-mark";
 import { ButtonLink } from "@/components/button-link";
+import { Colophon } from "@/components/colophon";
 import { JsonLd } from "@/components/json-ld";
 import { MdxContent } from "@/components/mdx/mdx-content";
 import { getAllArticleSlugs, getArticleBySlug } from "@/lib/articles";
@@ -124,7 +125,10 @@ export default async function ArticlePage({
           </div>
           <ArticleToc headings={article.headings} />
         </div>
-        <footer className="mt-16 pt-8 border-t border-border">
+        <div className="mt-16">
+          <Colophon />
+        </div>
+        <footer className="mt-12 pt-8 border-t border-border">
           <ButtonLink internal link={{ href: "/articles" }}>
             ← Back to articles
           </ButtonLink>

--- a/app/articles/page.tsx
+++ b/app/articles/page.tsx
@@ -27,7 +27,7 @@ export default async function ArticlesPage() {
   const structuredData = {
     "@context": "https://schema.org",
     "@type": "Blog",
-    name: "William Pei — Articles",
+    name: "William Pei: Articles",
     description: metadata.description,
     url: "https://www.wpei.me/articles",
     author: {

--- a/app/colophon/opengraph-image.tsx
+++ b/app/colophon/opengraph-image.tsx
@@ -20,7 +20,6 @@ export default async function Image() {
         fontFamily: "Figtree",
       }}
     >
-      {/* Top row */}
       <div
         style={{
           display: "flex",
@@ -40,34 +39,30 @@ export default async function Image() {
           wpei.me
         </span>
       </div>
-
-      {/* Main content */}
-      <div style={{ display: "flex", flexDirection: "column", gap: 24 }}>
+      <div style={{ display: "flex", flexDirection: "column", gap: 16 }}>
         <span
           style={{
-            fontSize: 80,
-            fontWeight: 600,
+            fontFamily: "JetBrains Mono",
+            fontSize: 72,
+            fontWeight: 500,
             color: OG_COLORS.fg,
-            lineHeight: 1.05,
-            letterSpacing: "-0.03em",
+            lineHeight: 1.1,
+            letterSpacing: "-0.02em",
           }}
         >
-          Parasol
+          Colophon
         </span>
         <span
           style={{
             fontSize: 26,
             color: OG_COLORS.muted,
             lineHeight: 1.5,
-            maxWidth: 700,
+            maxWidth: 720,
           }}
         >
-          A private FIRE calculator that keeps your data yours, no open banking
-          access required.
+          Where AI helped, where it didn&apos;t, and what stays mine.
         </span>
       </div>
-
-      {/* Bottom row */}
       <div
         style={{
           display: "flex",
@@ -83,14 +78,9 @@ export default async function Image() {
             letterSpacing: "0.06em",
           }}
         >
-          @application
+          @colophon
         </span>
-        <span
-          style={{
-            fontSize: 20,
-            color: OG_COLORS.muted,
-          }}
-        >
+        <span style={{ fontSize: 20, color: OG_COLORS.muted }}>
           William Pei
         </span>
       </div>

--- a/app/colophon/page.tsx
+++ b/app/colophon/page.tsx
@@ -1,6 +1,15 @@
 import type { Metadata } from "next";
+import Link from "next/link";
 import { BrandMark } from "@/components/brand-mark";
 import { ButtonLink } from "@/components/button-link";
+import {
+  Breadcrumb,
+  BreadcrumbItem,
+  BreadcrumbLink,
+  BreadcrumbList,
+  BreadcrumbPage,
+  BreadcrumbSeparator,
+} from "@/components/ui/breadcrumb";
 
 export const metadata: Metadata = {
   title: "Colophon | William Pei",
@@ -33,7 +42,7 @@ function Section({
           {label}
         </p>
       </div>
-      <h2 className="text-2xl md:text-3xl font-mono font-medium tracking-tight">
+      <h2 className="text-2xl md:text-3xl font-mono font-medium tracking-tight text-balance">
         {heading}
       </h2>
       <div className="space-y-4 text-muted-foreground leading-relaxed max-w-prose">
@@ -46,16 +55,28 @@ function Section({
 export default function ColophonPage() {
   return (
     <article className="container mx-auto pt-16 pb-24 max-w-3xl">
+      <Breadcrumb className="mb-12">
+        <BreadcrumbList className="font-mono text-sm">
+          <BreadcrumbItem>
+            <BreadcrumbLink render={<Link href="/" />}>Home</BreadcrumbLink>
+          </BreadcrumbItem>
+          <BreadcrumbSeparator />
+          <BreadcrumbItem>
+            <BreadcrumbPage>Colophon</BreadcrumbPage>
+          </BreadcrumbItem>
+        </BreadcrumbList>
+      </Breadcrumb>
+
       <header className="mb-12 space-y-4">
-        <h1 className="font-mono font-medium tracking-tight leading-tight text-[clamp(1.875rem,1rem+3vw,3rem)]">
+        <h1 className="font-mono font-medium tracking-tight leading-tight text-balance text-[clamp(1.875rem,1rem+3vw,3rem)]">
           <BrandMark className="text-primary mr-2" />
           Colophon
         </h1>
-        <p className="text-lg text-foreground leading-relaxed max-w-prose">
-          I work with AI, and I&apos;d rather say so plainly than let you guess.
-          This page is the honest account of how the site, the articles, and the
-          case studies get made, drawn at the level where the truth actually
-          lives.
+        <p className="text-lg text-foreground leading-relaxed text-pretty max-w-prose">
+          I work with AI, and I would rather say so plainly than leave you
+          guessing. What follows is an honest account of how the site, the
+          articles, and the case studies come together, written at the level
+          where the truth actually lives.
         </p>
       </header>
 
@@ -64,17 +85,18 @@ export default function ColophonPage() {
           label="principle"
           heading="Credit goes to the role, not the keystroke"
         >
-          <p>
-            For anything here there are three separable things, and they have
-            genuinely different origins: the experience and judgment behind a
+          <p className="text-pretty">
+            Three things sit behind anything published here, and they come from
+            genuinely different places: the experience and judgment driving a
             piece, the words and code that express it, and the accountability
-            for publishing it. I name all three rather than collapse them.
+            for putting it out. Rather than collapse those into a single claim,
+            I name each one.
           </p>
-          <p>
-            Tagging individual sentences as &ldquo;mine&rdquo; or &ldquo;the
-            AI&apos;s&rdquo; would claim a precision that does not exist; the
-            work is braided. So I attribute by role instead. The line that
-            matters most:{" "}
+          <p className="text-pretty">
+            Why not tag individual sentences as &ldquo;mine&rdquo; or &ldquo;the
+            AI&apos;s&rdquo;? Because the work is braided, and that kind of
+            labelling would claim a precision that does not exist. Attribution
+            by role is the honest unit. The line that matters most:{" "}
             <span className="text-foreground">
               AI can draft the telling of a true story. It never invents the
               story.
@@ -86,18 +108,18 @@ export default function ColophonPage() {
           label="articles"
           heading="Co-written, fully verified, mine to answer for"
         >
-          <p>
+          <p className="text-pretty">
             The incidents, opinions, and technical judgment in my writing are
-            real and my own: the production failures happened to me, the design
-            decisions were mine to make. I co-write the prose with Claude,
-            working through a writing process I built and keep refining.
+            real and my own. The production failures happened to me; the design
+            decisions were mine to make. The prose itself is co-written with
+            Claude, through a writing process I built and keep refining.
           </p>
-          <p>
-            Before anything publishes, every factual claim is checked against
-            its source: the real repository, the actual type signatures, the
-            published docs. When the source contradicts a draft, the source
-            wins. I read every line and I stand behind all of it, regardless of
-            who typed the first version.
+          <p className="text-pretty">
+            Nothing publishes until every factual claim has been checked against
+            its source, whether that is the real repository, the actual type
+            signatures, or the published docs, and when a draft and its source
+            disagree, the source wins. I read every line, and whoever typed the
+            first version, the final words are mine to answer for.
           </p>
         </Section>
 
@@ -105,12 +127,12 @@ export default function ColophonPage() {
           label="case studies"
           heading="Real projects, co-written write-ups"
         >
-          <p>
+          <p className="text-pretty">
             Parasol, North Shore Meditation, Waystone.Monads, and
-            Waystone.WideLogEvents are my own work, designed, built, and shipped
-            by me. The case-study pages that describe them were co-written with
-            Claude, and every claim about how the projects work is mine and
-            verified.
+            Waystone.WideLogEvents are my own work: designed, built, and shipped
+            by me. The case-study pages describing them were co-written with
+            Claude, and every claim about how the projects actually work is mine
+            and verified before it goes up.
           </p>
         </Section>
 
@@ -118,30 +140,30 @@ export default function ColophonPage() {
           label="this site"
           heading="A hand-authored original, rebuilt with AI"
         >
-          <p>
-            The first version of this portfolio (the original design and the
-            site it produced) was authored entirely by hand, no AI involved. The
-            version you are reading now grew out of that one: I rebuilt it with
-            heavy AI assistance, using{" "}
+          <p className="text-pretty">
+            The first version of this portfolio, both the original design and
+            the site it produced, was authored entirely by hand, with no AI
+            involved. What you are reading now grew out of that earlier version:
+            I rebuilt it with heavy AI assistance, leaning on{" "}
             <span className="text-foreground">Claude Code</span> for the
             engineering and a design process I drive for the interface.
           </p>
-          <p>
+          <p className="text-pretty">
             The architecture, the design decisions, the content, and the final
-            review are mine. The original is the foundation; this is its
-            AI-assisted descendant.
+            review remain mine throughout. The original is the foundation; this
+            is its AI-assisted descendant.
           </p>
         </Section>
 
         <Section label="why" heading="Honesty is the easy call here">
-          <p>
-            This is a portfolio about ideas and judgment, and those are the
-            parts that are unambiguously mine. Saying where AI helped costs me
-            nothing and earns the trust of the people most likely to assume the
-            worst if I stayed quiet. It is also just the consistent thing to do:
-            I already credit the lineage of an idea when I write; crediting the
-            tools that help produce the words is the same standard, one layer
-            down.
+          <p className="text-pretty">
+            This is a portfolio about ideas and judgment, and those parts are
+            unambiguously mine, so saying where AI helped costs me nothing while
+            earning the trust of the people most likely to assume the worst if I
+            stayed quiet. It is also simply the consistent thing to do: I
+            already credit the lineage of an idea when I write, and crediting
+            the tools that help produce the words is that same standard, one
+            layer down.
           </p>
         </Section>
       </div>

--- a/app/colophon/page.tsx
+++ b/app/colophon/page.tsx
@@ -1,0 +1,156 @@
+import type { Metadata } from "next";
+import { BrandMark } from "@/components/brand-mark";
+import { ButtonLink } from "@/components/button-link";
+
+export const metadata: Metadata = {
+  title: "Colophon | William Pei",
+  description:
+    "How this site, its articles, and its case studies are made, and where AI helped, where it didn't, and what stays mine.",
+  alternates: {
+    canonical: "/colophon",
+  },
+  openGraph: {
+    siteName: "William Pei",
+    url: "/colophon",
+    type: "article",
+  },
+};
+
+function Section({
+  label,
+  heading,
+  children,
+}: {
+  label: string;
+  heading: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <section className="space-y-4">
+      <div className="flex items-center gap-3">
+        <BrandMark className="text-primary shrink-0" />
+        <p className="font-mono text-sm text-secondary tracking-wider">
+          {label}
+        </p>
+      </div>
+      <h2 className="text-2xl md:text-3xl font-mono font-medium tracking-tight">
+        {heading}
+      </h2>
+      <div className="space-y-4 text-muted-foreground leading-relaxed max-w-prose">
+        {children}
+      </div>
+    </section>
+  );
+}
+
+export default function ColophonPage() {
+  return (
+    <article className="container mx-auto pt-16 pb-24 max-w-3xl">
+      <header className="mb-12 space-y-4">
+        <h1 className="font-mono font-medium tracking-tight leading-tight text-[clamp(1.875rem,1rem+3vw,3rem)]">
+          <BrandMark className="text-primary mr-2" />
+          Colophon
+        </h1>
+        <p className="text-lg text-foreground leading-relaxed max-w-prose">
+          I work with AI, and I&apos;d rather say so plainly than let you guess.
+          This page is the honest account of how the site, the articles, and the
+          case studies get made, drawn at the level where the truth actually
+          lives.
+        </p>
+      </header>
+
+      <div className="space-y-12">
+        <Section
+          label="principle"
+          heading="Credit goes to the role, not the keystroke"
+        >
+          <p>
+            For anything here there are three separable things, and they have
+            genuinely different origins: the experience and judgment behind a
+            piece, the words and code that express it, and the accountability
+            for publishing it. I name all three rather than collapse them.
+          </p>
+          <p>
+            Tagging individual sentences as &ldquo;mine&rdquo; or &ldquo;the
+            AI&apos;s&rdquo; would claim a precision that does not exist; the
+            work is braided. So I attribute by role instead. The line that
+            matters most:{" "}
+            <span className="text-foreground">
+              AI can draft the telling of a true story. It never invents the
+              story.
+            </span>
+          </p>
+        </Section>
+
+        <Section
+          label="articles"
+          heading="Co-written, fully verified, mine to answer for"
+        >
+          <p>
+            The incidents, opinions, and technical judgment in my writing are
+            real and my own: the production failures happened to me, the design
+            decisions were mine to make. I co-write the prose with Claude,
+            working through a writing process I built and keep refining.
+          </p>
+          <p>
+            Before anything publishes, every factual claim is checked against
+            its source: the real repository, the actual type signatures, the
+            published docs. When the source contradicts a draft, the source
+            wins. I read every line and I stand behind all of it, regardless of
+            who typed the first version.
+          </p>
+        </Section>
+
+        <Section
+          label="case studies"
+          heading="Real projects, co-written write-ups"
+        >
+          <p>
+            Parasol, North Shore Meditation, Waystone.Monads, and
+            Waystone.WideLogEvents are my own work, designed, built, and shipped
+            by me. The case-study pages that describe them were co-written with
+            Claude, and every claim about how the projects work is mine and
+            verified.
+          </p>
+        </Section>
+
+        <Section
+          label="this site"
+          heading="A hand-authored original, rebuilt with AI"
+        >
+          <p>
+            The first version of this portfolio (the original design and the
+            site it produced) was authored entirely by hand, no AI involved. The
+            version you are reading now grew out of that one: I rebuilt it with
+            heavy AI assistance, using{" "}
+            <span className="text-foreground">Claude Code</span> for the
+            engineering and a design process I drive for the interface.
+          </p>
+          <p>
+            The architecture, the design decisions, the content, and the final
+            review are mine. The original is the foundation; this is its
+            AI-assisted descendant.
+          </p>
+        </Section>
+
+        <Section label="why" heading="Honesty is the easy call here">
+          <p>
+            This is a portfolio about ideas and judgment, and those are the
+            parts that are unambiguously mine. Saying where AI helped costs me
+            nothing and earns the trust of the people most likely to assume the
+            worst if I stayed quiet. It is also just the consistent thing to do:
+            I already credit the lineage of an idea when I write; crediting the
+            tools that help produce the words is the same standard, one layer
+            down.
+          </p>
+        </Section>
+      </div>
+
+      <footer className="mt-16 pt-8 border-t border-border">
+        <ButtonLink internal link={{ href: "/" }}>
+          ← Back home
+        </ButtonLink>
+      </footer>
+    </article>
+  );
+}

--- a/app/colophon/page.tsx
+++ b/app/colophon/page.tsx
@@ -75,8 +75,7 @@ export default function ColophonPage() {
         <p className="text-lg text-foreground leading-relaxed text-pretty max-w-prose">
           I work with AI, and I would rather say so plainly than leave you
           guessing. What follows is an honest account of how the site, the
-          articles, and the case studies come together, written at the level
-          where the truth actually lives.
+          articles, and the case studies come together.
         </p>
       </header>
 
@@ -95,8 +94,8 @@ export default function ColophonPage() {
           <p className="text-pretty">
             Why not tag individual sentences as &ldquo;mine&rdquo; or &ldquo;the
             AI&apos;s&rdquo;? Because the work is braided, and that kind of
-            labelling would claim a precision that does not exist. Attribution
-            by role is the honest unit. The line that matters most:{" "}
+            labelling would claim a precision that does not exist. The line that
+            matters most:{" "}
             <span className="text-foreground">
               AI can draft the telling of a true story. It never invents the
               story.
@@ -158,12 +157,12 @@ export default function ColophonPage() {
         <Section label="why" heading="Honesty is the easy call here">
           <p className="text-pretty">
             This is a portfolio about ideas and judgment, and those parts are
-            unambiguously mine, so saying where AI helped costs me nothing while
-            earning the trust of the people most likely to assume the worst if I
-            stayed quiet. It is also simply the consistent thing to do: I
-            already credit the lineage of an idea when I write, and crediting
-            the tools that help produce the words is that same standard, one
-            layer down.
+            unambiguously mine. Saying where AI helped takes nothing away from
+            that, and anyone wondering how the work was made deserves a straight
+            answer rather than a guess. It is also simply the consistent thing
+            to do: I already credit the lineage of an idea when I write, and
+            crediting the tools that help produce the words is that same
+            standard, one layer down.
           </p>
         </Section>
       </div>

--- a/app/globals.css
+++ b/app/globals.css
@@ -62,7 +62,7 @@
   --secondary: oklch(0.38 0.09 318.07);
   --secondary-foreground: oklch(0.21 0.006 285.885);
   --muted: oklch(0.97 0.001 106.424);
-  --muted-foreground: oklch(0.553 0.013 58.071);
+  --muted-foreground: oklch(0.52 0.013 58.071);
   --accent: oklch(0.97 0.001 106.424);
   --accent-foreground: oklch(0.216 0.006 56.043);
   --destructive: oklch(0.577 0.245 27.325);
@@ -94,7 +94,7 @@
   --popover-foreground: oklch(0.8877 0.0288 218.97);
   --primary: oklch(0.6823 0.176 46.72);
   --primary-foreground: oklch(0.98 0.016 73.684);
-  --secondary: oklch(0.5579 0.0909 318.07);
+  --secondary: oklch(0.74 0.0909 318.07);
   --secondary-foreground: oklch(0.985 0 0);
   --muted: oklch(0.268 0.007 34.298);
   --muted-foreground: oklch(0.709 0.01 56.259);

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -103,7 +103,7 @@ export default async function Page() {
                   A SaaS application for tracking Financial Independence, Retire
                   Early (FIRE) progress. Built with TanStack Start for type-safe
                   full-stack routing, Neon for serverless Postgres, and Clerk
-                  for auth — so the infrastructure scales to zero when
+                  for auth, so the infrastructure scales to zero when
                   you&apos;re not using it.
                 </ProjectSummaryDescription>
               </ProjectSummaryHeader>
@@ -139,7 +139,7 @@ export default async function Page() {
                   <CarouselItem>
                     <Image
                       src="/parasol-hero-dark-mobile.png"
-                      alt="Parasol — FIRE tracking dashboard"
+                      alt="Parasol: FIRE tracking dashboard"
                       width={1179}
                       height={2556}
                       className="hidden dark:block sm:dark:hidden w-full h-auto rounded-lg"
@@ -147,7 +147,7 @@ export default async function Page() {
                     />
                     <Image
                       src="/parasol-hero-light-mobile.png"
-                      alt="Parasol — FIRE tracking dashboard"
+                      alt="Parasol: FIRE tracking dashboard"
                       width={1179}
                       height={2556}
                       className="block dark:hidden sm:hidden w-full h-auto rounded-lg"
@@ -155,7 +155,7 @@ export default async function Page() {
                     />
                     <Image
                       src="/parasol-hero-dark.png"
-                      alt="Parasol — FIRE tracking dashboard"
+                      alt="Parasol: FIRE tracking dashboard"
                       width={1920}
                       height={1080}
                       className="hidden sm:dark:block w-full h-auto rounded-lg"
@@ -163,7 +163,7 @@ export default async function Page() {
                     />
                     <Image
                       src="/parasol-hero-light.png"
-                      alt="Parasol — FIRE tracking dashboard"
+                      alt="Parasol: FIRE tracking dashboard"
                       width={1920}
                       height={1080}
                       className="hidden sm:block sm:dark:hidden w-full h-auto rounded-lg"
@@ -173,28 +173,28 @@ export default async function Page() {
                   <CarouselItem>
                     <Image
                       src="/parasol-feature-dark-mobile.png"
-                      alt="Parasol — portfolio and progress features"
+                      alt="Parasol: portfolio and progress features"
                       width={1179}
                       height={2556}
                       className="hidden dark:block sm:dark:hidden w-full h-auto rounded-lg"
                     />
                     <Image
                       src="/parasol-feature-light-mobile.png"
-                      alt="Parasol — portfolio and progress features"
+                      alt="Parasol: portfolio and progress features"
                       width={1179}
                       height={2556}
                       className="block dark:hidden sm:hidden w-full h-auto rounded-lg"
                     />
                     <Image
                       src="/parasol-feature-dark.png"
-                      alt="Parasol — portfolio and progress features"
+                      alt="Parasol: portfolio and progress features"
                       width={1920}
                       height={1080}
                       className="hidden sm:dark:block w-full h-auto rounded-lg"
                     />
                     <Image
                       src="/parasol-feature-light.png"
-                      alt="Parasol — portfolio and progress features"
+                      alt="Parasol: portfolio and progress features"
                       width={1920}
                       height={1080}
                       className="hidden sm:block sm:dark:hidden w-full h-auto rounded-lg"
@@ -263,7 +263,7 @@ export default async function Page() {
                   <CarouselItem>
                     <Image
                       src="/north-shore-meditation-hero-dark-mobile.png"
-                      alt="North Shore Meditation — homepage hero"
+                      alt="North Shore Meditation: homepage hero"
                       width={1179}
                       height={2556}
                       className="hidden dark:block sm:dark:hidden w-full h-auto rounded-lg"
@@ -271,7 +271,7 @@ export default async function Page() {
                     />
                     <Image
                       src="/north-shore-meditation-hero-light-mobile.png"
-                      alt="North Shore Meditation — homepage hero"
+                      alt="North Shore Meditation: homepage hero"
                       width={1179}
                       height={2556}
                       className="block dark:hidden sm:hidden w-full h-auto rounded-lg"
@@ -279,7 +279,7 @@ export default async function Page() {
                     />
                     <Image
                       src="/north-shore-meditation-hero-dark.png"
-                      alt="North Shore Meditation — homepage hero"
+                      alt="North Shore Meditation: homepage hero"
                       width={1920}
                       height={1080}
                       className="hidden sm:dark:block w-full h-auto rounded-lg"
@@ -287,7 +287,7 @@ export default async function Page() {
                     />
                     <Image
                       src="/north-shore-meditation-hero-light.png"
-                      alt="North Shore Meditation — homepage hero"
+                      alt="North Shore Meditation: homepage hero"
                       width={1920}
                       height={1080}
                       className="hidden sm:block sm:dark:hidden w-full h-auto rounded-lg"
@@ -297,28 +297,28 @@ export default async function Page() {
                   <CarouselItem>
                     <Image
                       src="/north-shore-meditation-science-dark-mobile.png"
-                      alt="North Shore Meditation — backed by science section"
+                      alt="North Shore Meditation: backed by science section"
                       width={1179}
                       height={2556}
                       className="hidden dark:block sm:dark:hidden w-full h-auto rounded-lg"
                     />
                     <Image
                       src="/north-shore-meditation-science-light-mobile.png"
-                      alt="North Shore Meditation — backed by science section"
+                      alt="North Shore Meditation: backed by science section"
                       width={1179}
                       height={2556}
                       className="block dark:hidden sm:hidden w-full h-auto rounded-lg"
                     />
                     <Image
                       src="/north-shore-meditation-science-dark.png"
-                      alt="North Shore Meditation — backed by science section"
+                      alt="North Shore Meditation: backed by science section"
                       width={1920}
                       height={1080}
                       className="hidden sm:dark:block w-full h-auto rounded-lg"
                     />
                     <Image
                       src="/north-shore-meditation-science-light.png"
-                      alt="North Shore Meditation — backed by science section"
+                      alt="North Shore Meditation: backed by science section"
                       width={1920}
                       height={1080}
                       className="hidden sm:block sm:dark:hidden w-full h-auto rounded-lg"
@@ -467,7 +467,7 @@ builder.Host.UseSerilog((context, config) => config
 app.UseWideLogEventsContext();
 app.UseSerilogRequestLogging();
 
-// Push properties — all flush together at request end
+// Push properties, all flush together at request end
 WideLogEventContext.PushProperty("userId", userId);
 WideLogEventContext.PushProperty("action", "checkout");`}
               />
@@ -510,8 +510,8 @@ WideLogEventContext.PushProperty("action", "checkout");`}
           Let&apos;s work together.
         </h2>
         <p className="max-w-prose text-muted-foreground mb-8">
-          I take on consulting and contract work alongside my role at InfoTrack
-          — distributed .NET systems, TypeScript, developer tooling, and
+          I take on consulting and contract work alongside my role at InfoTrack:
+          distributed .NET systems, TypeScript, developer tooling, and
           architecture. Open to open-source collaborations too. If what I build
           is relevant to your problem, reach out.
         </p>

--- a/app/projects/north-shore-meditation/page.tsx
+++ b/app/projects/north-shore-meditation/page.tsx
@@ -5,6 +5,7 @@ import { BrandMark } from "@/components/brand-mark";
 import { ButtonLink } from "@/components/button-link";
 import { Code } from "@/components/code";
 import { CodeBlock } from "@/components/code-block";
+import { Colophon } from "@/components/colophon";
 import { FrameworkBadge } from "@/components/framework-badge";
 import { JsonLd } from "@/components/json-ld";
 import {
@@ -70,7 +71,7 @@ export default function NorthShoreMeditationPage() {
             North Shore Meditation
           </h1>
           <p className="text-lg md:text-xl text-foreground leading-relaxed">
-            A site the client can actually maintain — events, articles, and page
+            A site the client can actually maintain: events, articles, and page
             content managed entirely from their dashboard.
           </p>
           <div className="flex items-center gap-3 flex-wrap">
@@ -133,28 +134,28 @@ export default function NorthShoreMeditationPage() {
               <CarouselItem>
                 <Image
                   src="/north-shore-meditation-science-dark-mobile.png"
-                  alt="North Shore Meditation — backed by science section"
+                  alt="North Shore Meditation: backed by science section"
                   width={1179}
                   height={2556}
                   className="hidden dark:block sm:dark:hidden w-full h-auto rounded-lg"
                 />
                 <Image
                   src="/north-shore-meditation-science-light-mobile.png"
-                  alt="North Shore Meditation — backed by science section"
+                  alt="North Shore Meditation: backed by science section"
                   width={1179}
                   height={2556}
                   className="block dark:hidden sm:hidden w-full h-auto rounded-lg"
                 />
                 <Image
                   src="/north-shore-meditation-science-dark.png"
-                  alt="North Shore Meditation — backed by science section"
+                  alt="North Shore Meditation: backed by science section"
                   width={1920}
                   height={1080}
                   className="hidden sm:dark:block w-full h-auto rounded-lg"
                 />
                 <Image
                   src="/north-shore-meditation-science-light.png"
-                  alt="North Shore Meditation — backed by science section"
+                  alt="North Shore Meditation: backed by science section"
                   width={1920}
                   height={1080}
                   className="hidden sm:block sm:dark:hidden w-full h-auto rounded-lg"
@@ -175,7 +176,7 @@ export default function NorthShoreMeditationPage() {
                 developer. Every content change was a bottleneck.
               </p>
               <p>
-                The client needed to own their content — publish events on their
+                The client needed to own their content: publish events on their
                 schedule, write articles when the moment was right, and update
                 page copy without friction.
               </p>
@@ -188,7 +189,7 @@ export default function NorthShoreMeditationPage() {
               <p>
                 A headless CMS architecture where Contentful handles all content
                 authoring and Next.js renders it. The client works entirely in
-                Contentful&apos;s dashboard — no code, no deployments, no
+                Contentful&apos;s dashboard: no code, no deployments, no
                 tickets.
               </p>
               <p>
@@ -217,7 +218,7 @@ export default function NorthShoreMeditationPage() {
               {
                 badge: "resend" as const,
                 rationale:
-                  "Reliable transactional email for contact form submissions. Simple API with strong deliverability — no SMTP configuration.",
+                  "Reliable transactional email for contact form submissions. Simple API with strong deliverability, no SMTP configuration.",
               },
               {
                 badge: "typescript" as const,
@@ -240,7 +241,7 @@ export default function NorthShoreMeditationPage() {
           <div className="space-y-16 max-w-3xl md:max-w-none">
             <div className="md:grid md:grid-cols-[11rem_1fr] md:gap-x-12">
               <p className="font-mono text-sm text-secondary mb-2 md:mb-0">
-                <BrandMark className="text-primary mr-1" /> 01 — performance
+                <BrandMark className="text-primary mr-1" /> 01 · performance
               </p>
               <div>
                 <h3 className="text-lg font-semibold mb-3">
@@ -253,7 +254,7 @@ export default function NorthShoreMeditationPage() {
                   <Code>React.memo</Code>, <Code>useMemo</Code>, and{" "}
                   <Code>useCallback</Code> through component files. The compiler
                   analyses the component tree at build time and memoizes only
-                  where it determines re-renders would be redundant — no manual
+                  where it determines re-renders would be redundant: no manual
                   decisions, no annotation drift, no incorrect dependency
                   arrays.
                 </p>
@@ -262,7 +263,7 @@ export default function NorthShoreMeditationPage() {
 
             <div className="md:grid md:grid-cols-[11rem_1fr] md:gap-x-12">
               <p className="font-mono text-sm text-secondary mb-2 md:mb-0">
-                <BrandMark className="text-primary mr-1" /> 02 — data fetching
+                <BrandMark className="text-primary mr-1" /> 02 · data fetching
               </p>
               <div>
                 <h3 className="text-lg font-semibold mb-3">
@@ -272,7 +273,7 @@ export default function NorthShoreMeditationPage() {
                   Every Contentful fetcher wraps its{" "}
                   <Code>queryClient.fetchQuery()</Code> call in React&apos;s{" "}
                   <Code>cache()</Code>. TanStack Query deduplicates client-side;{" "}
-                  <Code>cache()</Code> handles the server side — two Server
+                  <Code>cache()</Code> handles the server side: two Server
                   Components requesting the same article during a single render
                   cycle share one Contentful response. Without it, each
                   component tree branch that reads the same entry makes its own
@@ -287,7 +288,7 @@ export const getArticles = cache(async (options) => {
 });
 
 // Two Server Components can both call getArticles()
-// in the same render — Contentful is only hit once`}
+// in the same render: Contentful is only hit once`}
                   />
                 </div>
               </div>
@@ -295,7 +296,7 @@ export const getArticles = cache(async (options) => {
 
             <div className="md:grid md:grid-cols-[11rem_1fr] md:gap-x-12">
               <p className="font-mono text-sm text-secondary mb-2 md:mb-0">
-                <BrandMark className="text-primary mr-1" /> 03 — i18n
+                <BrandMark className="text-primary mr-1" /> 03 · i18n
               </p>
               <div>
                 <h3 className="text-lg font-semibold mb-3">
@@ -308,7 +309,7 @@ export const getArticles = cache(async (options) => {
                   runtime to the client. Libraries like <Code>next-intl</Code>{" "}
                   or <Code>i18next</Code> add bundle weight and require
                   hydration; the JSON approach simply can&apos;t be imported in
-                  a client component — TypeScript will reject it at build time.
+                  a client component; TypeScript will reject it at build time.
                 </p>
                 <div className="max-w-2xl">
                   <CodeBlock
@@ -328,7 +329,7 @@ export async function getDictionary(locale: Locale) {
 
             <div className="md:grid md:grid-cols-[11rem_1fr] md:gap-x-12">
               <p className="font-mono text-sm text-secondary mb-2 md:mb-0">
-                <BrandMark className="text-primary mr-1" /> 04 — data layer
+                <BrandMark className="text-primary mr-1" /> 04 · data layer
               </p>
               <div>
                 <h3 className="text-lg font-semibold mb-3">
@@ -340,18 +341,18 @@ export async function getDictionary(locale: Locale) {
                   custom fetcher function is injected into every generated hook,
                   so authentication tokens, cache tags, and draft-mode flags
                   flow through automatically. Contentful schema changes
-                  regenerate types — mismatches become build errors before they
+                  regenerate types; mismatches become build errors before they
                   reach production.
                 </p>
                 <div className="max-w-2xl">
                   <CodeBlock
                     language="typescript"
-                    code={`// codegen.ts — custom fetcher injected into every generated hook
+                    code={`// codegen.ts: custom fetcher injected into every generated hook
 config:
   fetcher: "@/lib/fetcher#fetcher"
   addSuspenseQuery: true
 
-// Generated usage — fully typed, no hand-written wrapper
+// Generated usage: fully typed, no hand-written wrapper
 const { data } = useSuspenseGetArticlesQuery({ preview: isPreview })`}
                   />
                 </div>
@@ -359,6 +360,16 @@ const { data } = useSuspenseGetArticlesQuery({ preview: isPreview })`}
             </div>
           </div>
         </section>
+
+        <div className="max-w-3xl">
+          <Colophon>
+            <p>
+              North Shore Meditation is a site I designed and built for a real
+              client. This case study was co-written with Claude; every claim
+              about how it works is mine and verified.
+            </p>
+          </Colophon>
+        </div>
       </div>
     </>
   );

--- a/app/projects/north-shore-meditation/page.tsx
+++ b/app/projects/north-shore-meditation/page.tsx
@@ -361,7 +361,7 @@ const { data } = useSuspenseGetArticlesQuery({ preview: isPreview })`}
           </div>
         </section>
 
-        <div className="max-w-3xl">
+        <div className="mt-20">
           <Colophon>
             <p>
               I designed and shipped North Shore Meditation for a real client.

--- a/app/projects/north-shore-meditation/page.tsx
+++ b/app/projects/north-shore-meditation/page.tsx
@@ -364,9 +364,10 @@ const { data } = useSuspenseGetArticlesQuery({ preview: isPreview })`}
         <div className="max-w-3xl">
           <Colophon>
             <p>
-              North Shore Meditation is a site I designed and built for a real
-              client. This case study was co-written with Claude; every claim
-              about how it works is mine and verified.
+              I designed and shipped North Shore Meditation for a real client.
+              Claude and I wrote this case study together, though everything it
+              says about how the site works comes from me, verified against what
+              I built.
             </p>
           </Colophon>
         </div>

--- a/app/projects/parasol/page.tsx
+++ b/app/projects/parasol/page.tsx
@@ -5,6 +5,7 @@ import { BrandMark } from "@/components/brand-mark";
 import { ButtonLink } from "@/components/button-link";
 import { Code } from "@/components/code";
 import { CodeBlock } from "@/components/code-block";
+import { Colophon } from "@/components/colophon";
 import { FrameworkBadge } from "@/components/framework-badge";
 import { JsonLd } from "@/components/json-ld";
 import {
@@ -70,7 +71,7 @@ export default function ParasolPage() {
             Parasol
           </h1>
           <p className="text-lg md:text-xl text-foreground leading-relaxed">
-            A private FIRE calculator that keeps your data yours — no open
+            A private FIRE calculator that keeps your data yours, no open
             banking access required.
           </p>
           <div className="flex items-center gap-3 flex-wrap">
@@ -192,8 +193,8 @@ export default function ParasolPage() {
                 progress over time.
               </p>
               <p>
-                The infrastructure scales to zero when you&apos;re not using it
-                — no idle costs, no maintenance overhead.
+                The infrastructure scales to zero when you&apos;re not using it,
+                no idle costs, no maintenance overhead.
               </p>
             </div>
           </section>
@@ -206,7 +207,7 @@ export default function ParasolPage() {
               {
                 badge: "tanstack-start" as const,
                 rationale:
-                  "Type-safe full-stack routing with SSR and server functions. Every API boundary is typed end-to-end — no client/server mental split.",
+                  "Type-safe full-stack routing with SSR and server functions. Every API boundary is typed end-to-end, no client/server mental split.",
               },
               {
                 badge: "neon" as const,
@@ -216,12 +217,12 @@ export default function ParasolPage() {
               {
                 badge: "clerk" as const,
                 rationale:
-                  "Sessions, JWTs, OAuth — handled. I focused on the FIRE logic, not the security plumbing.",
+                  "Sessions, JWTs, OAuth: handled. I focused on the FIRE logic, not the security plumbing.",
               },
               {
                 badge: "typescript" as const,
                 rationale:
-                  "Strict mode throughout. Type-safe from DB schema to UI — schema changes surface as build errors.",
+                  "Strict mode throughout. Type-safe from DB schema to UI: schema changes surface as build errors.",
               },
             ].map(({ badge, rationale }) => (
               <div key={badge} className="space-y-2">
@@ -239,7 +240,7 @@ export default function ParasolPage() {
           <div className="space-y-16 max-w-3xl md:max-w-none">
             <div className="md:grid md:grid-cols-[11rem_1fr] md:gap-x-12">
               <p className="font-mono text-sm text-secondary mb-2 md:mb-0">
-                <BrandMark className="text-primary mr-1" /> 01 — validation
+                <BrandMark className="text-primary mr-1" /> 01 · validation
               </p>
               <div>
                 <h3 className="text-lg font-semibold mb-3">
@@ -248,7 +249,7 @@ export default function ParasolPage() {
                 <p className="text-muted-foreground leading-relaxed max-w-prose mb-6">
                   The project uses Effect for services and error handling
                   throughout. Introducing Zod alongside it created dual
-                  dependency for overlapping concerns — parsing, error types,
+                  dependency for overlapping concerns: parsing, error types,
                   pipeline integration. Effect Schema maps{" "}
                   <Code>ParseError</Code> directly into Effect&apos;s typed
                   error channel; Zod errors required manual bridging outside it.
@@ -256,12 +257,12 @@ export default function ParasolPage() {
                 <div className="max-w-2xl">
                   <CodeBlock
                     language="typescript"
-                    code={`// Zod — parse error escapes the typed pipeline
+                    code={`// Zod: parse error escapes the typed pipeline
 const result = schema.safeParse(input)
 if (!result.success) return { error: result.error }
 return doWork(result.data)
 
-// Effect Schema — parse error is a typed value in the same pipeline
+// Effect Schema: parse error is a typed value in the same pipeline
 yield* Schema.decodeUnknown(InputSchema)(input).pipe(
   Effect.mapError((e) => new DbError({ cause: e })),
   Effect.flatMap(doWork)
@@ -273,7 +274,7 @@ yield* Schema.decodeUnknown(InputSchema)(input).pipe(
 
             <div className="md:grid md:grid-cols-[11rem_1fr] md:gap-x-12">
               <p className="font-mono text-sm text-secondary mb-2 md:mb-0">
-                <BrandMark className="text-primary mr-1" /> 02 — forms
+                <BrandMark className="text-primary mr-1" /> 02 · forms
               </p>
               <div>
                 <h3 className="text-lg font-semibold mb-3">
@@ -281,20 +282,19 @@ yield* Schema.decodeUnknown(InputSchema)(input).pipe(
                 </h3>
                 <p className="text-muted-foreground leading-relaxed max-w-prose">
                   Preferences (currency, locale) use debounced auto-save. Plan
-                  settings — withdrawal rate, expected return, inflation — use
-                  an explicit save button. Numeric fields pass through
-                  intermediate invalid states while typing:{" "}
-                  <Code>&quot;4.&quot;</Code> mid-entry of{" "}
-                  <Code>&quot;4.5%&quot;</Code>. Auto-saving at that moment
-                  would silently corrupt every downstream FIRE projection.
-                  Stale-but-complete beats live-but-partial.
+                  settings (withdrawal rate, expected return, inflation) use an
+                  explicit save button. Numeric fields pass through intermediate
+                  invalid states while typing: <Code>&quot;4.&quot;</Code>{" "}
+                  mid-entry of <Code>&quot;4.5%&quot;</Code>. Auto-saving at
+                  that moment would silently corrupt every downstream FIRE
+                  projection. Stale-but-complete beats live-but-partial.
                 </p>
               </div>
             </div>
 
             <div className="md:grid md:grid-cols-[11rem_1fr] md:gap-x-12">
               <p className="font-mono text-sm text-secondary mb-2 md:mb-0">
-                <BrandMark className="text-primary mr-1" /> 03 — performance
+                <BrandMark className="text-primary mr-1" /> 03 · performance
               </p>
               <div>
                 <h3 className="text-lg font-semibold mb-3">
@@ -302,7 +302,7 @@ yield* Schema.decodeUnknown(InputSchema)(input).pipe(
                 </h3>
                 <p className="text-muted-foreground leading-relaxed max-w-prose mb-6">
                   Dense transaction and portfolio lists need one element to
-                  respond when a sibling is hovered — row highlight when an
+                  respond when a sibling is hovered: row highlight when an
                   action button is hovered, for example. Tracking this with{" "}
                   <Code>useState</Code> and <Code>onMouseEnter</Code>/
                   <Code>onMouseLeave</Code> triggers re-renders on every hover
@@ -328,7 +328,7 @@ yield* Schema.decodeUnknown(InputSchema)(input).pipe(
 
             <div className="md:grid md:grid-cols-[11rem_1fr] md:gap-x-12">
               <p className="font-mono text-sm text-secondary mb-2 md:mb-0">
-                <BrandMark className="text-primary mr-1" /> 04 — data model
+                <BrandMark className="text-primary mr-1" /> 04 · data model
               </p>
               <div>
                 <h3 className="text-lg font-semibold mb-3">
@@ -339,7 +339,7 @@ yield* Schema.decodeUnknown(InputSchema)(input).pipe(
                   paid (cost basis) and what it&apos;s worth now (market close).
                   Conflating them silently corrupts unrealised gain
                   calculations. <Code>transaction.pricePerUnit</Code> is the
-                  price the user paid at trade time — it never changes after
+                  price the user paid at trade time; it never changes after
                   recording. <Code>security_prices.adjustedClose</Code> is
                   nightly market close data from Yahoo Finance. These serve
                   different purposes and are never substituted: P&L uses cost
@@ -350,6 +350,16 @@ yield* Schema.decodeUnknown(InputSchema)(input).pipe(
             </div>
           </div>
         </section>
+
+        <div className="max-w-3xl">
+          <Colophon>
+            <p>
+              Parasol is my own work. I designed and built it. This case study
+              was co-written with Claude; every claim about how it works is mine
+              and verified.
+            </p>
+          </Colophon>
+        </div>
       </div>
     </>
   );

--- a/app/projects/parasol/page.tsx
+++ b/app/projects/parasol/page.tsx
@@ -351,7 +351,7 @@ yield* Schema.decodeUnknown(InputSchema)(input).pipe(
           </div>
         </section>
 
-        <div className="max-w-3xl">
+        <div className="mt-20">
           <Colophon>
             <p>
               Parasol is something I designed and built. I co-wrote the write-up

--- a/app/projects/parasol/page.tsx
+++ b/app/projects/parasol/page.tsx
@@ -354,9 +354,9 @@ yield* Schema.decodeUnknown(InputSchema)(input).pipe(
         <div className="max-w-3xl">
           <Colophon>
             <p>
-              Parasol is my own work. I designed and built it. This case study
-              was co-written with Claude; every claim about how it works is mine
-              and verified.
+              Parasol is something I designed and built. I co-wrote the write-up
+              with Claude, and any description of how it works is mine, checked
+              against the source before it went up.
             </p>
           </Colophon>
         </div>

--- a/app/projects/parasol/structured-data.json
+++ b/app/projects/parasol/structured-data.json
@@ -5,7 +5,7 @@
       "@type": "SoftwareApplication",
       "name": "Parasol",
       "applicationCategory": "FinanceApplication",
-      "description": "A private FIRE calculator that keeps your data yours — no open banking access required. Track Financial Independence, Retire Early progress with manual entry. Built with TanStack Start, Neon for serverless Postgres, and Clerk for auth.",
+      "description": "A private FIRE calculator that keeps your data yours, no open banking access required. Track Financial Independence, Retire Early progress with manual entry. Built with TanStack Start, Neon for serverless Postgres, and Clerk for auth.",
       "url": "https://parasol.wpei.me",
       "image": "https://www.wpei.me/parasol-hero-light.png",
       "operatingSystem": "Web",

--- a/app/projects/waystone-monads/page.tsx
+++ b/app/projects/waystone-monads/page.tsx
@@ -222,7 +222,7 @@ return result.Match(
           </div>
         </section>
 
-        <div className="max-w-3xl">
+        <div className="mt-20">
           <Colophon>
             <p>
               Waystone.Monads is an open-source library I wrote. Claude helped

--- a/app/projects/waystone-monads/page.tsx
+++ b/app/projects/waystone-monads/page.tsx
@@ -225,9 +225,9 @@ return result.Match(
         <div className="max-w-3xl">
           <Colophon>
             <p>
-              Waystone.Monads is my own open-source library. This case study was
-              co-written with Claude; every claim about how the code works is
-              mine and verified against the source.
+              Waystone.Monads is an open-source library I wrote. Claude helped
+              me draft this write-up, but the explanations of how the code
+              behaves are my own, each one checked back against the source.
             </p>
           </Colophon>
         </div>

--- a/app/projects/waystone-monads/page.tsx
+++ b/app/projects/waystone-monads/page.tsx
@@ -4,6 +4,7 @@ import { BrandMark } from "@/components/brand-mark";
 import { ButtonLink } from "@/components/button-link";
 import { Code } from "@/components/code";
 import { CodeBlock } from "@/components/code-block";
+import { Colophon } from "@/components/colophon";
 import { FrameworkBadge } from "@/components/framework-badge";
 import { JsonLd } from "@/components/json-ld";
 import { ProjectSectionHeading } from "@/components/project-section";
@@ -116,7 +117,7 @@ export default async function WaystoneMonadsPage() {
             </p>
             <p>
               Rust&apos;s <Code>Option</Code> and <Code>Result</Code> types
-              solve this elegantly — you cannot access the inner value without
+              solve this elegantly: you cannot access the inner value without
               handling both cases. Waystone.Monads brings that discipline to
               .NET, without requiring F# or abandoning idiomatic C# patterns.
             </p>
@@ -144,7 +145,7 @@ export default async function WaystoneMonadsPage() {
                   code={`// A user may or may not exist for a given id
 Option<User> user = repository.Find(id);
 
-// Pattern match — compiler ensures both cases are handled
+// Pattern match: compiler ensures both cases are handled
 return user.Match(
     onSome: u => Results.Ok(u),
     onNone: () => Results.NotFound()
@@ -220,6 +221,16 @@ return result.Match(
             </div>
           </div>
         </section>
+
+        <div className="max-w-3xl">
+          <Colophon>
+            <p>
+              Waystone.Monads is my own open-source library. This case study was
+              co-written with Claude; every claim about how the code works is
+              mine and verified against the source.
+            </p>
+          </Colophon>
+        </div>
       </div>
     </>
   );

--- a/app/projects/waystone-monads/structured-data.json
+++ b/app/projects/waystone-monads/structured-data.json
@@ -4,7 +4,7 @@
     {
       "@type": "SoftwareSourceCode",
       "name": "Waystone.Monads",
-      "description": "A .NET implementation of Option<T> and Result<T,E> monads inspired by Rust's standard library. Makes impossible states impossible at the type level — eliminates null reference exceptions and untyped exceptions from domain logic.",
+      "description": "A .NET implementation of Option<T> and Result<T,E> monads inspired by Rust's standard library. Makes impossible states impossible at the type level: eliminates null reference exceptions and untyped exceptions from domain logic.",
       "codeRepository": "https://github.com/draekien-industries/waystone-dotnet",
       "programmingLanguage": "C#",
       "runtimePlatform": ".NET Standard 2.0",

--- a/app/projects/waystone-wide-log-events/page.tsx
+++ b/app/projects/waystone-wide-log-events/page.tsx
@@ -4,6 +4,7 @@ import { BrandMark } from "@/components/brand-mark";
 import { ButtonLink } from "@/components/button-link";
 import { Code } from "@/components/code";
 import { CodeBlock } from "@/components/code-block";
+import { Colophon } from "@/components/colophon";
 import { ExpandableInstallCommand } from "@/components/expandable-install-command";
 import { FrameworkBadge } from "@/components/framework-badge";
 import { JsonLd } from "@/components/json-ld";
@@ -101,8 +102,8 @@ export default async function WaystoneWideLogEventsPage() {
             <p>
               Debugging distributed systems meant correlating dozens of
               fragmented log entries per request. A single user action could
-              scatter context across 30+ log lines — different timestamps,
-              different log levels, different services — and you had to mentally
+              scatter context across 30+ log lines (different timestamps,
+              different log levels, different services) and you had to mentally
               stitch them together.
             </p>
             <p>
@@ -122,7 +123,7 @@ export default async function WaystoneWideLogEventsPage() {
               <p className="text-muted-foreground mb-6 lg:mb-0 max-w-prose">
                 Configure Serilog with the <Code>WideLogEventsContext</Code>{" "}
                 enricher and middleware. The library integrates with{" "}
-                <Code>Serilog.AspNetCore</Code> — your existing request logging
+                <Code>Serilog.AspNetCore</Code>; your existing request logging
                 pipeline stays intact.
               </p>
             </div>
@@ -137,7 +138,7 @@ builder.Host.UseSerilog((context, config) => config
 
 var app = builder.Build();
 
-// Middleware order matters — register before UseSerilogRequestLogging
+// Middleware order matters: register before UseSerilogRequestLogging
 app.UseWideLogEventsContext();
 app.UseSerilogRequestLogging();`}
               />
@@ -162,7 +163,7 @@ app.UseSerilogRequestLogging();`}
                 </p>
                 <CodeBlock
                   language="csharp"
-                  code={`// In a handler, service, or middleware — anywhere in the request
+                  code={`// In a handler, service, or middleware: anywhere in the request
 WideLogEventContext.PushProperty("userId", userId);
 WideLogEventContext.PushProperty("action", "checkout");
 WideLogEventContext.PushProperty("cartItemCount", cart.Items.Count);
@@ -187,7 +188,7 @@ WideLogEventContext.PushProperty("totalValue", cart.Total);
                 </p>
                 <CodeBlock
                   language="csharp"
-                  code={`// Tune per-level sample rates — errors and fatals always emit
+                  code={`// Tune per-level sample rates: errors and fatals always emit
 builder.Host.UseSerilog((context, config) => config
     .Enrich.FromWideLogEventsContext()
     .Filter.WithWideLogEventsSampling(options =>
@@ -243,6 +244,16 @@ builder.Host.UseSerilog((context, config) => config
             ))}
           </div>
         </section>
+
+        <div className="max-w-3xl">
+          <Colophon>
+            <p>
+              Waystone.WideLogEvents is my own open-source library. This case
+              study was co-written with Claude; every claim about how the code
+              works is mine and verified against the source.
+            </p>
+          </Colophon>
+        </div>
       </div>
     </>
   );

--- a/app/projects/waystone-wide-log-events/page.tsx
+++ b/app/projects/waystone-wide-log-events/page.tsx
@@ -248,9 +248,10 @@ builder.Host.UseSerilog((context, config) => config
         <div className="max-w-3xl">
           <Colophon>
             <p>
-              Waystone.WideLogEvents is my own open-source library. This case
-              study was co-written with Claude; every claim about how the code
-              works is mine and verified against the source.
+              I wrote and open-sourced Waystone.WideLogEvents myself. The case
+              study that follows was co-written with Claude. Wherever I describe
+              how the code works, that account is mine, and I confirmed it
+              against the source.
             </p>
           </Colophon>
         </div>

--- a/app/projects/waystone-wide-log-events/page.tsx
+++ b/app/projects/waystone-wide-log-events/page.tsx
@@ -245,7 +245,7 @@ builder.Host.UseSerilog((context, config) => config
           </div>
         </section>
 
-        <div className="max-w-3xl">
+        <div className="mt-20">
           <Colophon>
             <p>
               I wrote and open-sourced Waystone.WideLogEvents myself. The case

--- a/app/projects/waystone-wide-log-events/structured-data.json
+++ b/app/projects/waystone-wide-log-events/structured-data.json
@@ -4,7 +4,7 @@
     {
       "@type": "SoftwareSourceCode",
       "name": "Waystone.WideLogEvents",
-      "description": "A .NET library implementing the wide events logging pattern. Accumulates properties throughout a request's lifetime and flushes them as a single structured log event — solving context correlation in distributed systems.",
+      "description": "A .NET library implementing the wide events logging pattern. Accumulates properties throughout a request's lifetime and flushes them as a single structured log event, solving context correlation in distributed systems.",
       "codeRepository": "https://github.com/draekien-industries/waystone-dotnet",
       "programmingLanguage": "C#",
       "runtimePlatform": [".NET Standard 2.0", ".NET 8", ".NET 10"],

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -25,6 +25,12 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
       priority: 0.9,
     },
     {
+      url: "https://www.wpei.me/colophon",
+      lastModified: new Date(),
+      changeFrequency: "monthly",
+      priority: 0.5,
+    },
+    {
       url: "https://www.wpei.me/projects/parasol",
       lastModified: new Date(),
       changeFrequency: "monthly",

--- a/components/brand-mark.tsx
+++ b/components/brand-mark.tsx
@@ -1,7 +1,7 @@
 import type { SVGProps } from "react";
 import { cn } from "@/lib/utils";
 
-// Geometry sourced from public/mark.svg — left two diagonal bars only.
+// Geometry sourced from public/mark.svg: left two diagonal bars only.
 // viewBox clips at y=54; paths extend to y=58 by design to avoid edge gaps.
 export function BrandMark({ className, ...props }: SVGProps<SVGSVGElement>) {
   return (

--- a/components/colophon.tsx
+++ b/components/colophon.tsx
@@ -33,9 +33,8 @@ export function Colophon({
       <div className="mt-3 text-muted-foreground leading-relaxed">
         {children ?? (
           <p>
-            The experience and the argument here are mine. I co-wrote the prose
-            with Claude, and checked every claim against its source before
-            publishing. I stand behind all of it.
+            The thinking here is mine; I co-wrote the prose with Claude and
+            checked every claim against its source.
           </p>
         )}
       </div>

--- a/components/colophon.tsx
+++ b/components/colophon.tsx
@@ -20,12 +20,7 @@ export function Colophon({
   className,
 }: ColophonProps) {
   return (
-    <aside
-      className={cn(
-        "not-prose rounded-lg border border-border bg-muted p-6",
-        className,
-      )}
-    >
+    <aside className={cn("not-prose border-t border-border pt-6", className)}>
       <p className="flex items-center gap-2 font-mono text-sm text-secondary">
         <BrandMark className="text-primary" />
         {label}

--- a/components/colophon.tsx
+++ b/components/colophon.tsx
@@ -1,0 +1,49 @@
+import type { ReactNode } from "react";
+import { BrandMark } from "@/components/brand-mark";
+import { ButtonLink } from "@/components/button-link";
+import { cn } from "@/lib/utils";
+
+type ColophonProps = {
+  /** Override the mono `@`-kicker. Defaults to `@colophon`. */
+  label?: string;
+  /**
+   * The method note. Defaults to the article phrasing; case studies and other
+   * surfaces pass their own truthful split.
+   */
+  children?: ReactNode;
+  className?: string;
+};
+
+export function Colophon({
+  label = "@colophon",
+  children,
+  className,
+}: ColophonProps) {
+  return (
+    <aside
+      className={cn(
+        "not-prose rounded-lg border border-border bg-muted p-6",
+        className,
+      )}
+    >
+      <p className="flex items-center gap-2 font-mono text-sm text-secondary">
+        <BrandMark className="text-primary" />
+        {label}
+      </p>
+      <div className="mt-3 text-muted-foreground leading-relaxed">
+        {children ?? (
+          <p>
+            The experience and the argument here are mine. I co-wrote the prose
+            with Claude, and checked every claim against its source before
+            publishing. I stand behind all of it.
+          </p>
+        )}
+      </div>
+      <div className="mt-4">
+        <ButtonLink internal link={{ href: "/colophon" }}>
+          How this site is made →
+        </ButtonLink>
+      </div>
+    </aside>
+  );
+}

--- a/components/layout-header.tsx
+++ b/components/layout-header.tsx
@@ -24,6 +24,12 @@ export function LayoutHeader() {
         >
           articles
         </Link>
+        <Link
+          href="/colophon"
+          className="font-mono text-sm text-muted-foreground hover:text-foreground transition-colors duration-150"
+        >
+          colophon
+        </Link>
         <ButtonGroup>
           <Tooltip>
             <TooltipTrigger render={<ThemeToggle variant="ghost" />} />

--- a/content/articles/option-type-in-dotnet.mdx
+++ b/content/articles/option-type-in-dotnet.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Making null impossible: the Option type in .NET"
-description: "Rust deleted null from the language. This is how I ported its Option type to .NET — and what it teaches about designing absence into the type system itself."
+description: "Rust deleted null from the language. This is how I ported its Option type to .NET, and what it teaches about designing absence into the type system itself."
 date: "2026-06-02"
 tags: ["dotnet", "functional-programming", "rust", "type-safety"]
 ---
@@ -11,18 +11,18 @@ I kept hitting the same wall in production: <Define term="null-reference-excepti
 
 ## How Rust dodged null entirely
 
-Rust is a systems programming language — the kind you would reach for instead of C or C++. It is built around one stubborn idea: catch whole categories of bugs at compile time, before the code ever runs.
+Rust is a systems programming language, the kind you would reach for instead of C or C++. It is built around one stubborn idea: catch whole categories of bugs at compile time, before the code ever runs.
 
 So Rust made a radical choice. **It has no null.** There is no keyword for "nothing here." If a value can be absent, you say so in the type, using a built-in type called `Option`.
 
 An `Option<T>` is one of exactly two things:
 
-- `Some(value)` — the value is here.
-- `None` — the value is absent.
+- `Some(value)`: the value is here.
+- `None`: the value is absent.
 
 That is the whole type. There is no secret third state, no "present but actually null." It is what's called a <Define term="sum-type">sum type</Define>: a value that is exactly one of a fixed set of shapes, and the type spells out which shapes are allowed.
 
-The payoff is in how you read it back. To get at the value, you <Define term="pattern-matching">pattern match</Define> — you write a branch for each possible shape:
+The payoff is in how you read it back. To get at the value, you <Define term="pattern-matching">pattern match</Define>, writing a branch for each possible shape:
 
 ```rust
 match find_user(id) {
@@ -48,7 +48,7 @@ public User? FindById(Guid id)
 
 In theory the caller gets nudged. In practice, nullable warnings are suppressed, dismissed, or simply missed in review. The compiler is *asking politely*. It is not *requiring* anything.
 
-That is the gap. `User?` says "this might be null" but demands nothing of the caller. You can write `user.Name` with no check and the build still succeeds — at most you get a squiggle. The contract is advisory.
+That is the gap. `User?` says "this might be null" but demands nothing of the caller. You can write `user.Name` with no check and the build still succeeds; at most you get a squiggle. The contract is advisory.
 
 Rust's contract is enforced. I wanted to bring that enforcement to C#.
 
@@ -79,13 +79,13 @@ return result.Match(
 );
 ```
 
-Both branches are required. `Match` takes two callbacks, and there is no overload that accepts only one — leaving out the empty case is not something you can express. You get Rust's "handle every shape" guarantee, enforced by the method's signature instead of the compiler's `match` checker.
+Both branches are required. `Match` takes two callbacks, and there is no overload that accepts only one; leaving out the empty case is not something you can express. You get Rust's "handle every shape" guarantee, enforced by the method's signature instead of the compiler's `match` checker.
 
 ## Composition without the nesting
 
 Forcing a check at every step would be exhausting if you had to unwrap and rewrap by hand each time. This is where the design earns its keep, and where one word usually scares people off: *monad*.
 
-> **What's a monad?** Strip away the jargon. A monad is a wrapper around a value with two rules. You can transform what's inside without opening the box (`Map`). You can chain it with another step that returns its own box, and the boxes flatten into one instead of nesting (`FlatMap`). You never reach in and grab the raw value directly. `Option<T>` is one of the simplest monads there is — that is all the word means here.
+> **What's a monad?** Strip away the jargon. A monad is a wrapper around a value with two rules. You can transform what's inside without opening the box (`Map`). You can chain it with another step that returns its own box, and the boxes flatten into one instead of nesting (`FlatMap`). You never reach in and grab the raw value directly. `Option<T>` is one of the simplest monads there is; that is all the word means here.
 
 <Define term="map" code>Map</Define> transforms the inner value *if it exists*, and leaves `None` untouched:
 
@@ -105,17 +105,17 @@ Option<Order> latestOrder = repository
     .FlatMap(user => orderRepository.FindLatestByUser(user.Id));
 ```
 
-Each step either produces a value or short-circuits to `None`. Without `FlatMap` you would get an `Option<Option<Order>>` — a box inside a box. It flattens them for you. The happy path stays a clean, readable chain. You never accumulate the pyramid of guard clauses that null handling usually breeds.
+Each step either produces a value or short-circuits to `None`. Without `FlatMap` you would get an `Option<Option<Order>>`, a box inside a box. It flattens them for you. The happy path stays a clean, readable chain. You never accumulate the pyramid of guard clauses that null handling usually breeds.
 
 ## When to reach for it
 
 Not everywhere. Nullable reference types (`T?`) are fine for small, internal details where the absence is obvious from a glance at the surrounding code.
 
-`Option<T>` earns its place at boundaries — repository lookups, external service calls, anywhere absence is a legitimate outcome rather than an edge case to paper over. The question worth asking: *can this honestly return nothing?* If yes, the return type should say so out loud.
+`Option<T>` earns its place at boundaries: repository lookups, external service calls, anywhere absence is a legitimate outcome rather than an edge case to paper over. The question worth asking: *can this honestly return nothing?* If yes, the return type should say so out loud.
 
 `User?` says it optionally. `Option<User>` says it unambiguously.
 
-The overhead is real. You write `.Match()` where you might have written an `if`. But that is the entire point. The `if` is optional; the compiler shrugs if you skip it. The `.Match()` is not. Rust proved you can make the safe path the only path — porting that discipline to .NET is just a matter of deciding the politeness was never enough.
+The overhead is real. You write `.Match()` where you might have written an `if`. But that is the entire point. The `if` is optional; the compiler shrugs if you skip it. The `.Match()` is not. Rust proved you can make the safe path the only path; porting that discipline to .NET is just a matter of deciding the politeness was never enough.
 
 <SourceCallout internal href="/projects/waystone-monads" title="Waystone.Monads">
   The full case study: design rationale, the Option and Result API surface, and the .NET compatibility matrix.

--- a/content/articles/skills-that-teach.mdx
+++ b/content/articles/skills-that-teach.mdx
@@ -5,36 +5,36 @@ date: "2026-06-03"
 tags: ["agent-skills", "llm", "claude", "prompt-engineering"]
 ---
 
-A coding agent ran my skill and did something useless, perfectly. The skill told it to interview me before writing a technical spec. But the codebase already answered every question the interview would ask. The instructions said *interview, then write* — so it interviewed, invented questions, waited for answers it did not need, and produced a spec nobody wanted. It followed the letter and missed the point.
+A coding agent ran my skill and did something useless, perfectly. The skill told it to interview me before writing a technical spec. But the codebase already answered every question the interview would ask. The instructions said *interview, then write*, so it interviewed, invented questions, waited for answers it did not need, and produced a spec nobody wanted. It followed the letter and missed the point.
 
-That is the failure mode I want to talk about — and the skill was one of my own, from an earlier draft.
+That is the failure mode I want to talk about, and the skill was one of my own, from an earlier draft.
 
 ## What a skill is, and why mine broke
 
 An <Define term="agent-skill">agent skill</Define> is a folder you hand an AI agent to give it a capability it lacked. At its centre is a <Define term="skill-md" code>SKILL.md</Define> file: frontmatter that decides when the skill switches on, and a body of instructions the agent reads once it does. Think of it as onboarding docs for a teammate who is brilliant, fast, and has never met you.
 
-My first version of a skill *for writing skills* read like a bad runbook — seven numbered steps. **Step 1 — Gather requirements (ask these in order, one at a time).** Then literal scripted questions for the agent to recite:
+My first version of a skill *for writing skills* read like a bad runbook: seven numbered steps. **Step 1 · Gather requirements (ask these in order, one at a time).** Then literal scripted questions for the agent to recite:
 
 ```markdown
-**Question 1 — Purpose**
+**Question 1 · Purpose**
 > "What should this skill do? Describe the workflow or task it will handle."
 ```
 
 The body even instructed: *"Number steps sequentially. Map any decision trees explicitly: 'If X, go to step N. Otherwise, continue.'"*
 
-It demos beautifully. Every reviewer nods. And it is brittle in one specific way: it encodes one path through a task as if that path were the task. The moment reality diverges — the repo already holds the answers, a newer model needs less hand-holding, the request skips two steps — the agent can't notice. It was given a sequence to execute, not a goal to reach. So it executes, and fails politely.
+It demos beautifully. Every reviewer nods. And it is brittle in one specific way: it encodes one path through a task as if that path were the task. The moment reality diverges (the repo already holds the answers, a newer model needs less hand-holding, the request skips two steps), the agent can't notice. It was given a sequence to execute, not a goal to reach. So it executes, and fails politely.
 
 This is the trap I see in a lot of published skills. Walls of numbered steps. Strings of `MUST`, `ALWAYS`, `NEVER`. They read as careful. They are fragile, because the rigidity is load-bearing: remove the steps and nothing of the author's intent remains.
 
 ## Where I started: Anthropic's freedom dial
 
-I did not arrive at the seven-step version by being careless. I followed the best guidance available — Anthropic's own [skill-authoring documentation](https://platform.claude.com/docs/en/agents-and-tools/agent-skills/best-practices) and the `skill-creator` skill they ship with it. My first file was a fork of theirs, down to the name.
+I did not arrive at the seven-step version by being careless. I followed the best guidance available: Anthropic's own [skill-authoring documentation](https://platform.claude.com/docs/en/agents-and-tools/agent-skills/best-practices) and the `skill-creator` skill they ship with it. My first file was a fork of theirs, down to the name.
 
-Their central idea is genuinely good. They call it **<Define term="degrees-of-freedom">degrees of freedom</Define>**: match the latitude you give the agent to how fragile the task is. A narrow bridge with cliffs on both sides has one safe path, so you give exact instructions — *low freedom*. An open field has many routes across, so you give a direction and trust the agent to find one — *high freedom*. Three rungs:
+Their central idea is genuinely good. They call it **<Define term="degrees-of-freedom">degrees of freedom</Define>**: match the latitude you give the agent to how fragile the task is. A narrow bridge with cliffs on both sides has one safe path, so you give exact instructions: *low freedom*. An open field has many routes across, so you give a direction and trust the agent to find one: *high freedom*. Three rungs:
 
-- **High freedom** — prose heuristics, for when many approaches are valid.
-- **Medium freedom** — pseudocode or a parameterised template, for when a preferred shape exists but variation is fine.
-- **Low freedom** — an exact command, for when one wrong move breaks something.
+- **High freedom**: prose heuristics, for when many approaches are valid.
+- **Medium freedom**: pseudocode or a parameterised template, for when a preferred shape exists but variation is fine.
+- **Low freedom**: an exact command, for when one wrong move breaks something.
 
 That dial is the right mental model. But here is the detail that sent me down a month of rewrites: Anthropic's *own* example of a high-freedom instruction is this:
 
@@ -55,44 +55,44 @@ I kept using the skill, watched agents stumble on it, and kept editing. The comm
 
 ### Compression is not the goal
 
-My first instinct when a skill felt heavy was to make it terse — strip articles, shorten to a telegram. Smaller, surely better. It was not. Terseness saves tokens; it does not transfer intent. A clipped imperative is *more* brittle, because it strips the reasoning a reader needs to adapt. The <Define term="context-window">context window</Define> is finite and worth respecting — but you respect it by cutting what the agent already knows, not by compressing what it needs.
+My first instinct when a skill felt heavy was to make it terse: strip articles, shorten to a telegram. Smaller, surely better. It was not. Terseness saves tokens; it does not transfer intent. A clipped imperative is *more* brittle, because it strips the reasoning a reader needs to adapt. The <Define term="context-window">context window</Define> is finite and worth respecting, but you respect it by cutting what the agent already knows, not by compressing what it needs.
 
 ### Cut the procedure for choosing a procedure
 
-I had built three "modes" into the skill — create, update, refine — with logic to detect which applied. One day I saw it was the seven-step runbook again, one level up: a procedure for choosing a procedure. So I deleted it. I replaced the modes with a single standard the agent always works toward, and reframed the document around one sentence that now opens it:
+I had built three "modes" into the skill (create, update, refine) with logic to detect which applied. One day I saw it was the seven-step runbook again, one level up: a procedure for choosing a procedure. So I deleted it. I replaced the modes with a single standard the agent always works toward, and reframed the document around one sentence that now opens it:
 
-> A skill is a teaching document for a future LLM instance — it transfers intent and judgment so the agent can achieve a goal without the author present.
+> A skill is a teaching document for a future LLM instance: it transfers intent and judgment so the agent can achieve a goal without the author present.
 
 That line did more than any rule. Once a skill is a teaching document, "should I script this step or explain it?" answers itself: explain whatever the reader needs to think with; script only what they must not vary.
 
 ### Carry the why, not just the what
 
-This is the fix for the numbered-list contradiction. Any step that needs judgment should say what good looks like and *why* — an agent that understands the goal can adapt when the exact step does not fit; an agent holding only a command cannot. The contrast I put in the skill:
+This is the fix for the numbered-list contradiction. Any step that needs judgment should say what good looks like and *why*: an agent that understands the goal can adapt when the exact step does not fit; an agent holding only a command cannot. The contrast I put in the skill:
 
 - Weak: "Run `git status` to see uncommitted changes."
-- Strong: "Understand the working tree state before deciding what to stage — distinguish between intentional changes, generated artefacts, and files that might be sensitive."
+- Strong: "Understand the working tree state before deciding what to stage: distinguish between intentional changes, generated artefacts, and files that might be sensitive."
 
 The weak version is a keystroke. The strong version is a reason, and the keystroke follows from it. Bare commands are right only for deterministic operations, where variation is a bug.
 
 ### Stop hedging against the model
 
-I had inherited a section telling authors to *test the skill against every model tier* and add scaffolding for the weaker ones. I cut it; the commit message was blunt: *trust violation*. Crutches for a hypothetically weaker reader bloat the skill for the capable one and bake distrust into a document whose job is to transfer intent cleanly. Write for an intelligent reader. If a specific weak model can't cope, solve that at deployment — not by deadening the skill.
+I had inherited a section telling authors to *test the skill against every model tier* and add scaffolding for the weaker ones. I cut it; the commit message was blunt: *trust violation*. Crutches for a hypothetically weaker reader bloat the skill for the capable one and bake distrust into a document whose job is to transfer intent cleanly. Write for an intelligent reader. If a specific weak model can't cope, solve that at deployment, not by deadening the skill.
 
 ### The freedom dial has a blind spot
 
-This was the real lesson, underneath all the others. "Match freedom to fragility" assumes the only question is *how tightly* to specify a process. But sometimes the right amount of process is *none* — the judgment the agent needs is whether to run a procedure at all. My spec-writing skill failed there: no degree of freedom on the "interview" step would have helped, because the bug was that the step existed as a mandate. So I added a named anti-pattern, the part I am proudest of:
+This was the real lesson, underneath all the others. "Match freedom to fragility" assumes the only question is *how tightly* to specify a process. But sometimes the right amount of process is *none*: the judgment the agent needs is whether to run a procedure at all. My spec-writing skill failed there: no degree of freedom on the "interview" step would have helped, because the bug was that the step existed as a mandate. So I added a named anti-pattern, the part I am proudest of:
 
-> **Workflow scripting** — encoding a fixed sequence of steps when the task requires judgment about whether to follow a process at all... Recognise it by this tell: if removing every step header leaves nothing of substance, the steps were carrying the skill — not the intent.
+> **Workflow scripting**: encoding a fixed sequence of steps when the task requires judgment about whether to follow a process at all... Recognise it by this tell: if removing every step header leaves nothing of substance, the steps were carrying the skill, not the intent.
 
 That tell is now the first thing I check on anything I write. Delete the headings. If the skill collapses, the structure was a costume.
 
 ## When rigidity is right anyway
 
-None of this argues against structure. The narrow bridge is real. A database migration that must run in sequence, a destructive batch operation, a format another system will parse — these have one safe path, and there the right instruction is an exact command with a flat *do not modify this*. Low freedom is not the enemy; misapplied low freedom is. The failure is reaching for guardrails while standing in an open field.
+None of this argues against structure. The narrow bridge is real. A database migration that must run in sequence, a destructive batch operation, a format another system will parse: these have one safe path, and there the right instruction is an exact command with a flat *do not modify this*. Low freedom is not the enemy; misapplied low freedom is. The failure is reaching for guardrails while standing in an open field.
 
-And the principle-first style I have been selling has a real cost. Teaching skills lean harder on the reader: a weaker model handed "understand the working tree and use judgment" may do worse than one handed "run `git status`." They are harder to validate — you can lint a checklist, but not whether a paragraph transferred a way of thinking. And this end of the dial has its own failure mode: vague, vibe-shaped skills that gesture at intent and specify nothing, failing just as surely as the over-scripted ones, only more quietly.
+And the principle-first style I have been selling has a real cost. Teaching skills lean harder on the reader: a weaker model handed "understand the working tree and use judgment" may do worse than one handed "run `git status`." They are harder to validate: you can lint a checklist, but not whether a paragraph transferred a way of thinking. And this end of the dial has its own failure mode: vague, vibe-shaped skills that gesture at intent and specify nothing, failing just as surely as the over-scripted ones, only more quietly.
 
-So the honest rule is not "prefer freedom." It is the teaching test, applied per instruction: for each line, ask what the future agent needs to make this decision well without you in the room. Sometimes the answer is a reason; sometimes an exact command. The author's only real job is telling those two cases apart — and resisting the runbook that *feels* safe because it looks thorough.
+So the honest rule is not "prefer freedom." It is the teaching test, applied per instruction: for each line, ask what the future agent needs to make this decision well without you in the room. Sometimes the answer is a reason; sometimes an exact command. The author's only real job is telling those two cases apart, and resisting the runbook that *feels* safe because it looks thorough.
 
 My skill for writing skills is still changing. That is the point. The version that stops changing is the one that has quietly become a runbook again.
 

--- a/lib/glossary.ts
+++ b/lib/glossary.ts
@@ -57,7 +57,7 @@ export const glossary = {
   "agent-skill": {
     label: "Agent capability",
     summary:
-      "A folder of instructions — a SKILL.md file plus optional scripts and reference docs — that an AI agent loads on demand to gain a specific capability. Defined by the open standard at agentskills.io.",
+      "A folder of instructions (a SKILL.md file plus optional scripts and reference docs) that an AI agent loads on demand to gain a specific capability. Defined by the open standard at agentskills.io.",
     href: "https://agentskills.io/specification",
     hrefLabel: "The specification",
   },


### PR DESCRIPTION
## Summary

Refines the colophon across the site, both its visual treatment and its copy.

- **Flatten the card to a hairline rule.** The filled card (`rounded-lg border bg-muted p-6`) becomes a top hairline (`border-t border-border pt-6`). The `@colophon` kicker and surrounding whitespace already carry the voice shift, so the fill was redundant and stacked a surface beneath code blocks.
- **Fix case-study alignment.** All four case-study colophons (north-shore-meditation, parasol, waystone-monads, waystone-wide-log-events) now span the full container width at the page margin with whitespace above (`mt-20`), instead of the prior `max-w-3xl` that jutted left of the indented section grid.
- **Clarify the `/colophon` copy.** Reframed the "why" section away from a cost-benefit framing (`costs me nothing` to `takes nothing away from that`) and a cynical reader-as-skeptic clause to a straight answer for anyone wondering how the work was made. Dropped the grandiose intro tail and the jargon-flavoured "Attribution by role is the honest unit" line. Per-page attribution copy tightened.
- **Narrow gitignore** to `.impeccable/critique/` only.

## Verification

- `pnpm lint` clean (only pre-existing `components/ui/` infos remain).
- `pnpm build` succeeds.