### PR TITLE
Review article voice and apply priority fixes

### DIFF
--- a/content/articles/discernment-doesnt-come-in-the-box.mdx
+++ b/content/articles/discernment-doesnt-come-in-the-box.mdx
@@ -19,7 +19,7 @@ This incident is a small version of a much larger bet companies are making. The 
 
 It would be easy to read that as "a senior got sloppy." That misses the point. They were operating outside their domain, and the judgment that makes them excellent in .NET does not carry across the fence.
 
-This is the distinction the AI conversation keeps getting wrong. The useful fault line runs between *in-domain and out-of-domain* work, not junior versus senior. An expert frontend developer would have generated the same bad React and caught it on the first read; a backend expert cannot, because the catching is the expertise, and expertise is local. It is built one domain at a time and does not transfer because you are good somewhere else.
+The useful fault line runs between *in-domain and out-of-domain* work, not junior versus senior - and the AI conversation keeps missing it. An expert frontend developer would have generated the same bad React and caught it on the first read; a backend expert cannot, because the catching is the expertise, and expertise is local. It is built one domain at a time and does not transfer because you are good somewhere else.
 
 AI changes what each side can do, but not symmetrically. It raises the *floor*: anyone can produce code that compiles and roughly runs in a language they never learned. What it does not raise on its own is the *ceiling*, the judgment of whether that code is actually good, because that has to be earned rather than generated.
 
@@ -35,7 +35,7 @@ Two findings matter. The more someone trusted the AI, the less critical thinking
 
 ## The work we automate is the work that makes seniors
 
-Now connect that to how organisations actually deploy AI. The pressure I keep seeing is toward throughput: lines of code, pull requests, release frequency. Pick a number that looks like productivity, push AI at it, and AI will hit it. The moment you optimise a measure this hard it stops meaning anything - <Define term="goodharts-law">Goodhart's Law</Define> with an engine bolted on.
+Organisations deploy AI toward throughput: lines of code, pull requests, release frequency. Pick a number that looks like productivity, push AI at it, and AI will hit it. The moment you optimise a measure this hard it stops meaning anything - <Define term="goodharts-law">Goodhart's Law</Define> with an engine bolted on.
 
 But that framing hides a slower, worse cost almost nobody is pricing in. The work we are most eager to automate, the boilerplate, the first stumbling implementation, the bug you stare at for an hour, is the *exact* work that turns a junior into a senior. Discernment is accumulated rather than taught, built through reps: writing the wrong thing, feeling why it is wrong, getting feedback, trying again. That loop is the only path from floor to ceiling I have watched actually work, and it does not come in the box.
 
@@ -47,7 +47,7 @@ So an organisation optimising for output with AI does more than game a metric: i
 
 ## Cognitive debt comes due later
 
-The same risk has a sharper form at the individual level. Researchers at the MIT Media Lab call it <Define term="cognitive-debt">cognitive debt</Define>, in <LinkNote href="https://www.media.mit.edu/projects/your-brain-on-chatgpt/" note="A 2025 MIT Media Lab study (a preprint) that measured brain activity as people wrote essays with and without an LLM, reporting weaker neural engagement and recall among heavy AI users.">a 2025 study</LinkNote> modelled on technical debt, the shortcut that costs more the longer you defer it: leaning on an LLM saves effort now and charges interest later, in weaker memory, less original thinking, and a shallower grasp of work you only nominally produced.
+At the individual level the cost is sharper. Researchers at the MIT Media Lab call it <Define term="cognitive-debt">cognitive debt</Define>, in <LinkNote href="https://www.media.mit.edu/projects/your-brain-on-chatgpt/" note="A 2025 MIT Media Lab study (a preprint) that measured brain activity as people wrote essays with and without an LLM, reporting weaker neural engagement and recall among heavy AI users.">a 2025 study</LinkNote> modelled on technical debt, the shortcut that costs more the longer you defer it: leaning on an LLM saves effort now and charges interest later, in weaker memory, less original thinking, and a shallower grasp of work you only nominally produced.
 
 People who wrote essays with an LLM showed the weakest brain engagement and the lowest sense of ownership, and 83% could not quote a single sentence from what they had *just* written. As the lead author, Nataliya Kosmyna, put it: "There is no cognitive credit card. You cannot pay this debt off."
 

--- a/content/articles/option-type-in-dotnet.mdx
+++ b/content/articles/option-type-in-dotnet.mdx
@@ -13,7 +13,7 @@ I kept hitting the same wall in production: <Define term="null-reference-excepti
 
 Rust is a systems programming language, the kind you would reach for instead of C or C++. It is built around one stubborn idea: catch whole categories of bugs at compile time, before the code ever runs.
 
-So Rust made a radical choice. **It has no null.** There is no keyword for "nothing here." If a value can be absent, you say so in the type, using a built-in type called `Option`.
+So Rust made a radical choice. It has no null. There is no keyword for "nothing here." If a value can be absent, you say so in the type, using a built-in type called `Option`.
 
 An `Option<T>` is one of exactly two things:
 
@@ -31,7 +31,7 @@ match find_user(id) {
 }
 ```
 
-Here is the part that changes everything: **if you forget the `None` branch, the code does not compile.** Not a warning. A hard error. Rust forces you to confront absence at the exact moment you reach for the value. You physically cannot read `user.name` without first proving the user exists.
+Here is the part that changes everything: if you forget the `None` branch, the code does not compile. Not a warning. A hard error. Rust forces you to confront absence at the exact moment you reach for the value. You physically cannot read `user.name` without first proving the user exists.
 
 That is the bar I wanted in .NET.
 
@@ -113,9 +113,9 @@ Not everywhere. Nullable reference types (`T?`) are fine for small, internal det
 
 `Option<T>` earns its place at boundaries: repository lookups, external service calls, anywhere absence is a legitimate outcome rather than an edge case to paper over. The question worth asking: *can this honestly return nothing?* If yes, the return type should say so out loud.
 
-`User?` says it optionally. `Option<User>` says it unambiguously.
+`Option<User>` says absence is possible and forces the caller to handle it; `User?` only suggests it.
 
-The overhead is real. You write `.Match()` where you might have written an `if`. But that is the entire point. The `if` is optional; the compiler shrugs if you skip it. The `.Match()` is not. Rust proved you can make the safe path the only path; porting that discipline to .NET is just a matter of deciding the politeness was never enough.
+The overhead is real. You write `.Match()` where you might have written an `if`. But that is the entire point. The `if` is optional; the compiler shrugs if you skip it. The `.Match()` is not. Rust made the safe path the only path. The port brings that to .NET.
 
 <SourceCallout internal href="/projects/waystone-monads" title="Waystone.Monads">
   The full case study: design rationale, the Option and Result API surface, and the .NET compatibility matrix.

--- a/content/articles/skills-that-teach.mdx
+++ b/content/articles/skills-that-teach.mdx
@@ -30,11 +30,11 @@ This is the trap I see in a lot of published skills. Walls of numbered steps. St
 
 I did not arrive at the seven-step version by being careless. I followed the best guidance available: Anthropic's own <LinkNote href="https://platform.claude.com/docs/en/agents-and-tools/agent-skills/best-practices" note="Anthropic's official guide to authoring Claude agent skills: keeping them concise, matching degrees of freedom to task fragility, progressive disclosure, and iterating with evaluations.">skill-authoring documentation</LinkNote> and the `skill-creator` skill they ship with it. My first file was a fork of theirs, down to the name.
 
-Their central idea is genuinely good. They call it **<Define term="degrees-of-freedom">degrees of freedom</Define>**: match the latitude you give the agent to how fragile the task is. A narrow bridge with cliffs on both sides has one safe path, so you give exact instructions: *low freedom*. An open field has many routes across, so you give a direction and trust the agent to find one: *high freedom*. Three rungs:
+Their central idea is genuinely good. They call it <Define term="degrees-of-freedom">degrees of freedom</Define>: match the latitude you give the agent to how fragile the task is. A narrow bridge with cliffs on both sides has one safe path, so you give exact instructions: *low freedom*. An open field has many routes across, so you give a direction and trust the agent to find one: *high freedom*. Three rungs:
 
-- **High freedom**: prose heuristics, for when many approaches are valid.
-- **Medium freedom**: pseudocode or a parameterised template, for when a preferred shape exists but variation is fine.
-- **Low freedom**: an exact command, for when one wrong move breaks something.
+- High freedom - prose heuristics, for when many approaches are valid.
+- Medium freedom - pseudocode or a parameterised template, for when a preferred shape exists but variation is fine.
+- Low freedom - an exact command, for when one wrong move breaks something.
 
 That dial is the right mental model. But here is the detail that sent me down a month of rewrites: Anthropic's *own* example of a high-freedom instruction is this:
 
@@ -84,7 +84,7 @@ This was the real lesson, underneath all the others. "Match freedom to fragility
 
 > **Workflow scripting**: encoding a fixed sequence of steps when the task requires judgment about whether to follow a process at all... Recognise it by this tell: if removing every step header leaves nothing of substance, the steps were carrying the skill, not the intent.
 
-That tell is now the first thing I check on anything I write. Delete the headings. If the skill collapses, the structure was a costume.
+That tell is now the first thing I check on anything I write: delete the headings, and see whether the skill collapses.
 
 ## When rigidity is right anyway
 

--- a/docs/review-discernment-doesnt-come-in-the-box.md
+++ b/docs/review-discernment-doesnt-come-in-the-box.md
@@ -1,0 +1,50 @@
+# Voice review: "Discernment doesn't come in the box"
+
+## Verdict
+
+Reads strongly as William's voice. No critical mechanical violations (no em dashes, no American spelling, no exclamation chains, no scattered bold). The remaining issues are a handful of soft openers and one or two near-aphorisms, all minor.
+
+## What works
+
+- Conclusion-first throughout. The opening anecdote lands a verdict by paragraph four ("the damage... surfaces years later, in the seniors you no longer have") rather than building to it.
+- Certainty gradient is handled well. Verdicts stated flat; the forecast in the closing sections is labelled plainly as a forecast ("I should be honest that this is a forecast... I reason from a mechanism and from my own teams, not a settled result").
+- Limits declared without hedging-for-politeness: the preprint caveat ("54 participants and only 18 in the crucial session... I would not lean on it alone") and the survey caveat ("it rests on what people reported about their own habits, not on measured behaviour").
+- Counterpoints conceded directly ("The obvious objection is...", "Two counterarguments deserve an answer", the entire "What I don't have figured out" section).
+- Cause-effect-tension inline with hyphen connectors, used correctly ("Goodhart's Law with an engine bolted on", "confidently wrong at random, so the layer never goes solid enough to stand on").
+- Australian spelling consistent (memoise, optimise, organisations, behaviour).
+
+## Voice deviations
+
+- **Quote:** "The same risk has a sharper form at the individual level." (opening of the cognitive-debt section)
+  - **Violates:** Principle 1/2 (conclusion first, minimum words). This is a transitional frame that defers the substance rather than leading with it.
+  - **Fix:** Open with the finding: "At the individual level the cost is sharper. Researchers at the MIT Media Lab call it cognitive debt..."
+
+- **Quote:** "Now connect that to how organisations actually deploy AI."
+  - **Violates:** Principle 2 (throat-clearing / instruction to the reader rather than substance). A directive to the reader, not a claim.
+  - **Fix:** Cut it and lead with the claim: "Organisations deploy AI toward throughput: lines of code, pull requests, release frequency."
+
+- **Quote:** "This is the distinction the AI conversation keeps getting wrong."
+  - **Violates:** Principle 9 / sweeping framing. "The AI conversation" is a broad, slightly sweeping subject; the sentence is also a setup that delays the point made in the next sentence.
+  - **Fix:** Tighten and lead with the fault line: "The useful fault line runs between in-domain and out-of-domain work, not junior versus senior - and the AI conversation keeps missing it."
+
+- **Quote:** "and it does not come in the box."
+  - **Violates:** Aphorism-as-filler (the title echoed back in the body). It is a payoff line, not new information, but it is load-bearing as the article's thesis, so it earns its place once. Flagged only so you decide consciously to keep it.
+  - **Fix:** Acceptable to keep, since it is the single repetition of the title and carries the thesis. Remove only if you want zero aphoristic cadence.
+
+- **Quote:** "the people who could have reviewed the AI's output are the ones you forgot to grow."
+  - **Violates:** Borderline aphoristic two-beat cadence at a paragraph close. It is concrete enough to survive, but it is doing rhetorical rather than informational work.
+  - **Fix:** Acceptable as-is; if trimming, end on the prior clause "they never make the climb" and cut the flourish.
+
+- **Quote:** "racing to the bottom of a metric." (final words)
+  - **Violates:** Mild aphoristic flourish to close. The piece otherwise avoids closing recaps; this is a phrase-level ornament, not a recap, so it is within tolerance.
+  - **Fix:** Acceptable. No recap problem - the final paragraph adds the open question rather than summarising.
+
+- **Observation (not a deviation):** italic emphasis (`*derived state*`, `*floor*`, `*ceiling*`, `*exact*`, `*just*`, `*teaches*`, `*why*`, `*what*`, `*legible*`) appears frequently. The voice spec bans bold mid-sentence but is silent on italics. Usage here is for genuine emphasis on contrast words, not decoration, and reads consistent with his style. No change needed, but the density is worth a conscious check - eight-plus instances is near the ceiling of what reads as deliberate rather than tic.
+
+## Priority fixes
+
+1. "Now connect that to how organisations actually deploy AI." - cut the reader-directive, lead with the claim. (Clearest throat-clearing instance.)
+2. "The same risk has a sharper form at the individual level." - rewrite to lead with the cognitive-debt finding.
+3. "This is the distinction the AI conversation keeps getting wrong." - tighten the sweeping subject and front-load the fault line.
+
+Everything below these is optional polish. The piece has no mechanical violations and holds the certainty gradient and counterpoint discipline that mark his voice.

--- a/docs/review-option-type-in-dotnet.md
+++ b/docs/review-option-type-in-dotnet.md
@@ -1,0 +1,52 @@
+# Voice review: Making null impossible: the Option type in .NET
+
+## 1. Verdict
+
+Largely reads as William's voice - conclusion-first structure, certainty gradient handled well, no em dashes, Australian-clean spelling. The main deviations are decorative emphasis (italics and mid-sentence bold) and a couple of aphoristic two-beat closers that need flattening.
+
+## 2. What works
+
+- Opens on the verdict ("Null reference exceptions are the most preventable bugs in software") and discloses motive plainly ("I kept hitting the same wall in production"). No throat-clearing.
+- Em dashes are absent throughout; hyphens and `->`-free prose are used correctly. Australian spelling holds (no `behavior`, `optimize`, etc.).
+- Trade-offs sit inline: "The overhead is real. You write `.Match()` where you might have written an `if`. But that is the entire point." Cause-effect-tension in one breath.
+- Concrete examples over abstraction throughout. The monad blockquote earns its existence by removing jargon rather than adding it.
+- Credentials/motive stated flatly, not performed.
+
+## 3. Voice deviations
+
+- **Mid-sentence / mid-line bold for emphasis, not as a section label.**
+  - `So Rust made a radical choice. **It has no null.**` and `**if you forget the \`None\` branch, the code does not compile.**`
+  - Violates Mechanics ("No bold mid-sentence; bold only as section labels") and the scattered-bold anti-pattern.
+  - Fix: drop the bold and let the short declarative sentence carry the weight. "So Rust made a radical choice. It has no null." / "Here is the part that changes everything: if you forget the `None` branch, the code does not compile."
+  - Note: the `**What's a monad?**` label inside the blockquote is a legitimate section-label use of bold - leave it.
+
+- **Italic emphasis for stress (asterisk-italics).**
+  - `*monad*`, `*if it exists*`, `*themselves*`, `*asking politely*`, `*requiring*`, `*can this honestly return nothing?*`
+  - Not in his register; emphasis comes from word order and short sentences, not typographic stress. Reads as assistant-voice decoration.
+  - Fix: remove the italics. Where the stress is load-bearing, recast: "where one word usually scares people off: monad." / "Map transforms the inner value if it exists" / "FlatMap chains steps that themselves return an `Option`." For the question, "The question worth asking: can this honestly return nothing?" reads fine unitalicised.
+
+- **Aphoristic two-beat closers.**
+  - `\`User?\` says it optionally. \`Option<User>\` says it unambiguously.` and `\`User?\` says "this might be null" but demands nothing of the caller.`
+  - The paired-cadence "says X / says Y" is the aphoristic two-beat the register tells us to strip.
+  - Fix: collapse to one claim. "`Option<User>` says absence is possible and forces the caller to handle it; `User?` only suggests it." Keep a single sentence, lose the symmetry.
+
+- **Closing flourish borders on aphorism.**
+  - `Rust proved you can make the safe path the only path; porting that discipline to .NET is just a matter of deciding the politeness was never enough.`
+  - "the politeness was never enough" is a rhetorical button, slightly ornamental (Principle 14 - demand justification for the ornamental; Principle 2 - minimum words).
+  - Fix: end on the functional claim. "Rust made the safe path the only path. The port brings that to .NET." Cut the closing aphorism.
+
+- **Mild personification / advisory framing.**
+  - `The compiler is *asking politely*. It is not *requiring* anything.` and "at most you get a squiggle."
+  - Borderline - the personification is doing real explanatory work (advisory vs enforced contract), so it mostly earns its place. The italics are the actual problem here, covered above. "squiggle" is colloquial but concrete and fine.
+  - Fix: italics only; keep the framing.
+
+- **Single-word fragment opener.**
+  - `Not everywhere.` under "When to reach for it".
+  - Acceptable - it is conclusion-first answering the heading's implicit question, and the terse fragment matches the short-declarative register. No change needed; flagged only so it is a deliberate keep.
+
+## 4. Priority fixes
+
+1. Remove all asterisk-italic emphasis (six instances). This is the most pervasive voice tell.
+2. Remove the two mid-sentence bold spans ("It has no null", "if you forget the `None` branch..."); keep the `What's a monad?` label.
+3. Flatten the two-beat aphorisms (`says it optionally / says it unambiguously` and the `User?` says/demands pairing) into single claims.
+4. Cut the closing "the politeness was never enough" flourish; end on the functional statement.

--- a/docs/review-skills-that-teach.md
+++ b/docs/review-skills-that-teach.md
@@ -1,0 +1,49 @@
+# Voice review: skills-that-teach.mdx
+
+## 1. Verdict
+
+Reads convincingly as William's voice. Conclusion-first structure, certainty gradient, inline cause-effect, and concrete examples are all intact. The deviations are mechanical, not tonal: scattered bold mid-sentence and a habit of italic emphasis where his style relies on word choice instead.
+
+## 2. What works
+
+- Opens on the verdict, not a wind-up: "A coding agent ran my skill and did something useless, perfectly." That is the answer first, reasoning after.
+- Motive disclosed plainly - the broken skill was his own, stated flatly ("the skill was one of my own, from an earlier draft").
+- Concedes the strongest counterpoint in full ("When rigidity is right anyway" and the paragraph on the real cost of principle-first skills). This is principle 12 done well.
+- Australian English where it is his prose: "centre", "artefacts", "parameterised", "Recognise".
+- No em dashes anywhere. Hyphens and `...` carry the asides. Clean on the banned-connector rule.
+- Cause, effect and trade-off ride in the same sentence repeatedly ("Terseness saves tokens; it does not transfer intent").
+
+## 3. Voice deviations
+
+- **Scattered bold mid-sentence (multiple).** Bold should be section labels only, never emphasis inside running prose.
+  - "They call it **degrees of freedom**" (line 33) - bold wraps a `<Define>` mid-sentence.
+  - "- **High freedom**: prose heuristics..." / "- **Medium freedom**:..." / "- **Low freedom**:..." (lines 35-37) - inline bold lead-ins inside a dash list.
+  - "**Step 1 · Gather requirements...**" and "**Question 1 · Purpose**" (lines 16, 19) - these quote the old skill's own text, so they are arguably defensible as reproduction, but they still read as scattered bold to a reader.
+  - "**Workflow scripting**:" (line 85) and "**Code review process**" exists only inside a code block (fine).
+  - Fix: drop the bold. Let the `<Define>` component carry the visual weight for "degrees of freedom". For the freedom-dial list, write "High freedom - prose heuristics, for when many approaches are valid." Bold belongs on `##`/`###` headings, which the article already uses correctly.
+
+- **Italic emphasis as a tic (multiple).** His warmth and emphasis come from action words and sentence shape, not from italicising the operative word. Several are quotation/term italics (fine), but the emphasis italics are assistant-flavoured.
+  - "as if that path *were* the task" - cut italics; the contrast is already in the words.
+  - "it does not transfer intent. A clipped imperative is *more* brittle" (line 58) - cut.
+  - "say what good looks like and *why*" (line 70) - cut.
+  - "no degree of freedom on the 'interview' step would have helped" / "the runbook that *feels* safe" (line 95), "a skill *for writing skills*" (lines 16, 31), "Anthropic's *own* example" (line 39), "is *none*" (line 83), "the form of *maximum freedom*" (line 50, "*maximum freedom*").
+  - Fix: delete the emphasis italics. Keep italics only for genuine quotation of source text (e.g. the quoted instruction "*Number steps sequentially...*", "*trust violation*", "*do not modify this*", "*interview, then write*") where they mark reported speech. Trim the rest; the sentences stand without them.
+
+- **Aphoristic two-beat cadence (strip per public-prose register).** A few lines land as polished aphorism rather than plain statement.
+  - "the structure was a costume." (line 87) and "the structure was a costume" echoes the earlier "looks thorough" beat.
+  - "The version that stops changing is the one that has quietly become a runbook again." (line 97) - closing aphorism.
+  - "So it executes, and fails politely." (line 25) and "it interviewed, invented questions, waited for answers it did not need, and produced a spec nobody wanted. It followed the letter and missed the point." (line 8).
+  - Assessment: these are borderline. They are vivid and earned by the surrounding argument, not filler, so most can stay. The one to watch is "the structure was a costume" (line 87), which is the most ornamental and adds nothing the preceding sentence ("Delete the headings. If the skill collapses...") has not already said. Fix: consider cutting "the structure was a costume" as a recap of its own prior sentence.
+
+- **Mild closing-recap risk (line 95-97).** The final two paragraphs restate "the honest rule" after the body has already made the case. The "So the honest rule is not..." construction is a summary move. It is short and adds the per-instruction framing, so it earns its place, but verify it changes what the reader knows rather than recapping. No change required if it is doing work; tighten if it is echoing.
+
+- **Em-dash glyph check - clean.** No `—` present. The `·` middle dots (lines 16, 19) come from the quoted old-skill text, not his connective punctuation, so they do not violate the hyphen rule.
+
+- **American spelling - clean in his prose.** "Analyze", "organization", "maintainability" appear only inside the quoted Anthropic code block (lines 44-47). Those are reproduction of source, correctly left as-is. His own prose is Australian throughout.
+
+## 4. Priority fixes (ordered)
+
+1. Remove scattered bold from running prose and the freedom-dial list (lines 33, 35-37). This is the clearest mechanical violation and the easiest win.
+2. Cut emphasis italics that are not quoting source text (lines 25, 50, 58, 70, 83, 95 and the "*for writing skills*" / "*own*" instances). Keep only reported-speech italics.
+3. Cut "the structure was a costume" (line 87) as an ornamental recap of the sentence before it.
+4. Pressure-test the "So the honest rule is not..." closer (line 95) against the no-recap rule; keep only if it adds the per-instruction test rather than restating the body.


### PR DESCRIPTION
## Summary

Reviewed all three articles against William's written voice (ghost-writing skill) and applied the priority fixes from each review.

Voice reviews added under `docs/`:
- `review-option-type-in-dotnet.md`
- `review-discernment-doesnt-come-in-the-box.md`
- `review-skills-that-teach.md`

## Fixes applied

**option-type-in-dotnet** - removed two mid-sentence bold spans, flattened the `says it optionally / says it unambiguously` two-beat into a single claim, replaced the closing flourish with two flat sentences.

**discernment-doesnt-come-in-the-box** - cut two throat-clearing transitional openers so each leads with substance, folded the sweeping setup line into the fault-line sentence.

**skills-that-teach** - unbolded the `<Define>` term and converted the High/Medium/Low bold lead-ins to dash bullets, cut the "the structure was a costume" aphorism.

Italic emphasis left intact (approved as acceptable for these articles). Content-only MDX edits - no em dashes introduced.