### PR TITLE
docs: add lib/CLAUDE.md to resolve broken root reference

### DIFF
--- a/lib/CLAUDE.md
+++ b/lib/CLAUDE.md
@@ -1,0 +1,13 @@
+# lib/ — shared utilities
+
+**`articles.ts`** — the article pipeline. `getAllArticles`, `getArticleBySlug`, `getAllArticleSlugs`, all wrapped in React `cache()`. **Server-only** (uses `node:fs`) — do not import into Client Components. Frontmatter is parsed with the Zod `frontmatterSchema` here (the source of truth `content/articles/CLAUDE.md` documents). Drafts are filtered unless `NODE_ENV !== "production"`; a missing slug calls `notFound()`. Headings for the TOC are extracted with the regex `/^(#{2,3})\s+(.+)$/gm` and `slugify`d — this must stay in lockstep with how `rehype-slug` derives heading `id`s, or TOC anchors break.
+
+**`glossary.ts`** — the typed glossary backing `<Define term="...">`. Keys are the valid `term` values; an unregistered term is a TypeScript error. Add the entry here before using the component in MDX.
+
+**`opengraph.tsx`** — `OgMark`, `OG_COLORS`, `loadFonts` for the colocated `opengraph-image.tsx` routes (`next/og` `ImageResponse`). `loadFonts` reads TTFs from `public/fonts`.
+
+**`query-client.ts`** — `getQueryClient` singleton: a fresh client per request on the server, a memoized browser singleton on the client. Used by `components/query-client-provider.tsx`.
+
+**`use-scroll-spy.ts`** — `useScrollSpy(ids)` drives the active TOC section (midpoint model + bottom-of-page guard). `ids` must be a stable reference.
+
+**`hooks.ts`** — `useCopyToClipboard`. **`utils.ts`** — `cn` (clsx + tailwind-merge) and `assertDefined`.


### PR DESCRIPTION
## Summary

The root `CLAUDE.md` references `lib/CLAUDE.md` ("See `lib/CLAUDE.md`") but the file did not exist. This adds it, satisfying the existing cross-reference.

`lib/` is a substantive subsystem — the articles pipeline, the typed glossary backing `<Define>`, the OG-image toolkit, and the TanStack Query singleton — so it warrants its own context file as the root already promised.

## Contents

The new file documents the seven `lib/` modules, emphasising the non-obvious bits:
- `articles.ts` is server-only and its heading regex must track `rehype-slug`
- `glossary.ts` keys are compile-time-checked `<Define>` terms
- `query-client.ts`'s server-vs-browser singleton split

## Notes

Surfaced via the `/claude-md-management:claude-md-improver` audit. All other CLAUDE.md files were found current and accurate; this was the only defect.